### PR TITLE
Add loops, classes, module imports (leta), and IDE fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Local dev-environment scaffolding (DDEV/Lando) - machine-specific, not
+# part of the actual project.
+.ddev/
+.lando.yml
+
+# Local PHP framework/runtime cache used by the website shell (index.php,
+# lib/) that isn't part of the Hamri language project itself.
+data/
+lib/
+tmp/
+index.php
+.htaccess
+
+# Stale duplicate copy of the interpreter modules (pre-dates this port -
+# the real source lives at the repo root now, same as before).
+modules/
+
+# OS/editor cruft
+.DS_Store
+__pycache__/
+*.pyc
+
+# Editor/IDE
+.vscode/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,198 @@
+# Changelog
+
+## Unreleased — language feature expansion + interpreter fixes
+
+This is a large update that brings the interpreter up to date with an
+extended, independently-developed fork of Hamri (originally built out
+alongside a web Playground). It adds several new language features,
+fixes a number of pre-existing bugs, and reconciles `main.py`/`Notepad.py`
+with the updated interpreter's calling conventions. Every change below
+was verified with a Python test harness exercising the actual
+interpreter (`LexicalParser` → `StatementParser` → `.execute()`), plus a
+"docs pages" regression check that runs every code sample used to
+document the language and confirms it still executes successfully.
+
+### New language features
+
+- **`sivyo`** — an "otherwise" (else) branch for `kama`, e.g.
+  `kama ... sivyo ... kwisha`.
+- **`wakati`** — a `while` loop: `wakati <condition> ... kwisha`.
+- **`huku`** — a `for` loop with two forms: a counted range
+  (`huku i kutoka 0 hadi 10`, exclusive end, counts down automatically if
+  `hadi` is smaller than `kutoka`) and a for-each over a list
+  (`huku item kwenye orodha`).
+- **`rudisha`** — a real `return` statement. Properly unwinds through any
+  number of nested `kama`/`wakati`/`huku` blocks up to the enclosing
+  function/method call boundary (the previous `return_statement`
+  attempted this via a `set_return_value` method that didn't actually
+  exist anywhere in `SymbolTable`, so it could never have worked).
+- **Word-form operators** — `ongeza` (+), `punguza` (-), `mara` (*),
+  `gawa` (/), `sawa` (loose `==`), `kabisa`/`hakika` (strict equality,
+  checks type *and* value, e.g. `1 kabisa true` is false).
+- **Comments** — `# ...` to end of line, quote-aware (a `#` inside a
+  string literal is left alone).
+- **Lists (`orodha`)** — bracket literals (`[1, 2, 3]`), including
+  nested lists (`[[1, 2], [3, 4]]`); indexed read/write (`orodha[i]`,
+  `orodha[i] = x`); `weka <value> kwenye <list>` (append); `idadi <list>`
+  (length); `ondoa <index> kutoka <list>` (remove by position); and
+  `huku item kwenye orodha` for-each iteration.
+- **Classes (`darasa`)** — full basic OOP: `darasa Jina ... kwisha`
+  containing `eleza` method definitions; `nafsi` as an automatically
+  bound "self" (not a reserved keyword — it's just a variable name that
+  happens to get bound to the current instance before a method runs);
+  a `jenga` method name convention that's auto-invoked as the
+  constructor; dot notation for both properties and method calls
+  (`mtu1.jina`, `mtu1.sema()`); instances work like any other value
+  (can live in a list, be looped over, etc).
+- **`leta`** — imports from another file. Whole-class form:
+  `leta Mtu, Mnyama kutoka "faili"`. Selective method form (pulls out one
+  method as a standalone callable, without importing the whole class):
+  `leta salamu kutoka Mtu kutoka "faili"`. A library file's own `kwanza`
+  block (if it has one) is never executed as a side effect of importing
+  from it.
+- **`aina`** — prints what kind of value an expression holds (`namba`,
+  `neno`, `boolean`, `orodha`, or the class name for an object). This
+  keyword already existed in the original codebase (referenced in the
+  sample script in `main.py`) but its implementation was effectively
+  dead code — it dispatched to an `Object.return_type()` method that was
+  only ever overridden on `Var`, and even then returned a hardcoded,
+  malformed string. Reimplemented from scratch as a proper statement
+  (`aina <expr>`, matching `chapa`'s own bare-expression style, rather
+  than the original's function-call-style `aina(x)`).
+
+### Bug fixes
+
+- **`kama` (if) now actually does something.** Previously `kama` was
+  recognized by the lexer but had no corresponding branch in
+  `StatementParser.parseStatement` at all — it silently fell through to
+  a no-op. There were also no comparison operators (`==`, `!=`, `<`,
+  `>`, `<=`, `>=`) defined anywhere, so there was nothing to build a
+  condition with even if it had been wired up. Both are now fully
+  implemented, including `sivyo`/else branches and nesting inside
+  functions/loops/each other.
+- **Square brackets were never tokenized.** `divider` was written as
+  `r'(\\[|\\]|\(|\))'` — in a raw string that matches a literal
+  backslash followed by a bracket character, not the bracket itself, so
+  `[`/`]` silently never matched anything. Fixed to `r'(\[|\]|\(|\)|\.)'`
+  (the trailing `.` is new too, for property/method access).
+- **Token matching used substring search instead of a full match.**
+  `find_token_match` used `pattern.findall(...)`, so e.g. a string
+  containing a stray `(` could be misclassified as a divider. Switched
+  to `pattern.fullmatch(...)`.
+- **Boolean literals always evaluated true.** `Bool.evaluate()` did
+  `bool(self.token.capitalize())`, which is `True` for *any* non-empty
+  string, including the literal text `"false"`. Fixed to compare the
+  lowercased string against `'true'`.
+- **Self-referential assignment (`i = i + 1`) was broken.**
+  `Var.evaluate()`'s assignment path stored the *unevaluated* expression
+  object directly, so a variable's own stored value could reference
+  itself and recurse forever on read. Now evaluates immediately and
+  stores the plain result.
+- **Undefined function calls crashed with a raw Python `KeyError`**
+  instead of a clean Hamri-level error message. Now reports
+  `Kosa La Kazi` and stops the script gracefully.
+- **Local variables weren't isolated per function/method call.** Any
+  variable assigned inside a function body that wasn't one of its
+  declared parameters was stored under a single flat, shared key — so
+  once *any* function had assigned to (say) a local named `x`, every
+  other variable named `x` anywhere else in the program (including an
+  unrelated global) would permanently read back that function's last
+  value. Fixed by giving the interpreter a real call stack: locals,
+  `huku` loop variables, and `jaza` input variables are now isolated to
+  whichever call is actually executing.
+- **A "special value" (a function call, list index, `idadi`, or a
+  property/method read) could only ever be an entire expression on its
+  own**, e.g. `chapa square(2) + 1` or `chapa nafsi.jina + "!"` would
+  silently drop everything after the call/property. These now compose
+  normally with a trailing operator anywhere they appear — including as
+  a `kama`/`wakati` condition, a `huku` bound, or a function-call
+  argument. This also covers a second special value appearing *later* in
+  the same chain (e.g. `nafsi.jina + " anasema " + nafsi.sauti` — the
+  second property read used to silently fall back to printing the raw
+  object instead of its value).
+- **Running a script with no console/GUI attached (e.g. `main.py`,
+  run directly) produced no visible output at all.** `chapa`, `aina`,
+  and the run-start/success/failure banners only ever wrote to a
+  console object if one was supplied, with no fallback. All of them now
+  fall back to a plain `print()` when no console is attached, matching
+  how error messages already behaved.
+
+### Desktop IDE (`Notepad.py`)
+
+- **Added a "Run ▶" button** directly in the window, alongside "Clear
+  Editor" and "Clear Console" buttons - all three are also available from
+  the File menu (Execute / Clear Editor / Clear Console). On macOS, a
+  Tk app's menu bar renders in the system menu bar at the top of the
+  screen rather than inside the window, and a script launched straight
+  from a terminal (rather than a real `.app` bundle) doesn't always
+  grab menu focus reliably - so these buttons (plus a `Cmd+R`/`Ctrl+R`
+  keyboard shortcut bound directly to the root window) guarantee there's
+  always a way to run the script and clear either pane without depending
+  on the system menu bar working.
+- **Fixed a crash when pasting into the editor with nothing selected.**
+  `CustomText._proxy` (used to detect edits for syntax highlighting)
+  called straight into the underlying Tcl widget command with no error
+  handling. A `<<Paste>>` internally issues `delete sel.first sel.last`
+  even when there's no selection, which Tcl reports as an error ("text
+  doesn't contain any characters tagged with sel") instead of a no-op -
+  uncaught, that exception escaped straight out of Tk's mainloop and
+  silently killed the whole application. Now caught and treated as a
+  no-op, matching what a real no-op delete should do.
+
+### Repository cleanup
+
+- Removed everything not related to the actual Hamri language/interpreter:
+  the old PHP-based website shell (`index.php`, `lib/`, `data/`, `tmp/`),
+  the `ui/` folder (an HTML/JS Playground prototype), and local
+  dev-environment scaffolding (`.lando.yml`, `.venv/`). The repository is
+  now a plain, dependency-free Python codebase: clone it, run `main.py`
+  or `Notepad.py`, nothing else required.
+- **Still flagged, not yet removed**: `run.py` at the repo root calls
+  into `pyscript` (a browser-Python bridge) and isn't used by anything
+  else here, and `Logger.py.testcopy` is a leftover test artifact -
+  both are untracked and safe to delete whenever convenient; neither
+  will get committed by the commands below since they're never `git
+  add`-ed.
+
+### Other changes
+
+- `main.py` and `Notepad.py` updated for the new `LexicalParser`
+  constructor signature — pass `from_text=True` to parse literal source
+  text (as both files now do for in-memory/text-widget content); leaving
+  it out (the default) still treats the first argument as a file path,
+  same as before.
+- `main.py` now also accepts a script path as a command-line argument
+  (`python3 main.py path/to/script.ham`) and runs that instead of the
+  built-in sample when one is given.
+- `LexicalParser.read_source` (the file-path branch, `from_text=False`)
+  now checks the path exists and ends in `.ham` first, printing a clear
+  message and exiting instead of raising a raw traceback.
+- `Notepad.py`'s `__execute()` now resets interpreter state
+  (`symbolTable.reset()`) before each run, and passes the console Text
+  widget straight into `StatementParser.parse(...)` instead of routing
+  through `Console.py`'s `console.use_console(...)` singleton.
+  `Console.py` itself is left in place but is no longer imported
+  anywhere — same treatment as `Stack.py`/`Symbols.py`, which were
+  already unused, unimported prototypes before this change (a generic
+  stack class and a second, parallel `SymbolTable`/`Scope`
+  implementation, neither ever wired into anything).
+- Added `.gitignore` for local dev-environment/cache files that were
+  previously untracked-but-present locally (`data/`, `lib/`, `tmp/`,
+  `.ddev/`, `.lando.yml`, `index.php`, `.htaccess`, `.DS_Store`) and the
+  stale duplicate `modules/` folder (an older, pre-feature copy of the
+  same interpreter files now at the repo root).
+
+### Known pre-existing limitations (documented, not fixed here)
+
+- No parenthesized grouping in expressions, no decimal or negative
+  number literals, no inheritance or static/shared class variables, no
+  chained list indexing (`matrix[0][1]` — index into an intermediate
+  variable instead), and `ondoa` removes by position, not by value.
+- `Notepad.py`'s live syntax-highlighting (`__generateTags`) was already
+  non-functional before this change (it compares `token.type` — a bound
+  method, not the token's type string — against capitalized category
+  names that don't correspond to any of the lexer's actual token types,
+  and passes raw character offsets to Tkinter APIs that expect
+  `"line.column"` index strings). Left as-is; only the code-execution
+  path (`__execute()`) was fixed, since that's what was actually broken
+  by this change specifically.

--- a/Errors.py
+++ b/Errors.py
@@ -1,37 +1,118 @@
 from SymbolTable import symbolTable
 
+def _report(message):
+    # Route error text through whatever console the current run is using
+    # (Tk Text widget, the web IDE's console shim, ...) so it's actually
+    # visible there, same as chapa output. Falls back to print() for the
+    # plain CLI (main.py), which never sets a console.
+    if symbolTable.console is not None:
+        symbolTable.console.insert('end','{}\n'.format(message))
+    else:
+        print(message)
+
 class Errors:
     def __init__(self):
+
         self.exceptions = {
-            'anwani': VariableReferenceException  # Define an exception with key 'anwani' and value as VariableReferenceException class
+
+        'anwani': VariableReferenceException,
+        'kazi': FunctionReferenceException,
+        'mzunguko': LoopLimitException,
+        'fahirisi': IndexOutOfRangeException,
+        'orodha': NotAListException,
+        'darasa': NotAnObjectException,
+        'leta': ImportException
+
         }
-        
-    def throwException(self, arg, args=''):
-        self.exceptions[arg](args).execute()  # Instantiate the exception class based on the provided argument and execute it
-        
+
+    def throwException(self,arg,args=''):
+
+        self.exceptions[arg](args).execute()
+
 class VariableReferenceException:
-    def __init__(self, arg):
-        self.name = arg
-        
-    def execute(self):
-        print('Kosa La Anwani: Jina hili {' + self.name + '} halijulikani')  # Print an error message indicating unknown variable name
-        symbolTable.exit(1)  # Set the exit flag of the symbolTable instance to 1
-        
-class Exception:
-    def __init__(self, arg):
-        self.name = arg
-        
-    def execute(self):
-        pass  # Placeholder method for generic exception execution
 
-Error = Errors()  # Create an instance of the Errors class
+    def __init__(self,arg):
+        self.name = arg
 
-# Explanation:
-# - The Errors class handles exceptions and provides a mechanism to throw exceptions.
-# - It defines a dictionary, 'exceptions', which maps exception keys to exception classes.
-# - The 'throwException' method takes an argument to specify the type of exception and an optional argument.
-# - Based on the exception argument, the corresponding exception class is instantiated and executed.
-# - The 'VariableReferenceException' class handles variable reference exceptions.
-# - It prints an error message indicating an unknown variable name and sets the exit flag in the symbolTable instance.
-# - The 'Exception' class is a generic placeholder for other exceptions.
-# - The 'Errors' class is instantiated as 'Error'.
+    def execute(self):
+        _report('Kosa La Anwani: Jina hili {' +self.name +'} halijulikani')
+        symbolTable.exit(1)
+
+
+class FunctionReferenceException:
+    # 'kazi' = Swahili for "job/task" - used here for "function".
+
+    def __init__(self,arg):
+        self.name = arg
+
+    def execute(self):
+        _report('Kosa La Kazi: Kazi hii {' +self.name +'} haijaelezwa (undefined function)')
+        symbolTable.exit(1)
+
+
+class LoopLimitException:
+    # 'mzunguko' = Swahili for "loop/cycle" - a wakati loop that never
+    # became false ran too many iterations and was stopped, rather than
+    # freezing the page forever.
+
+    def __init__(self,arg):
+        self.name = arg
+
+    def execute(self):
+        _report('Kosa La Mzunguko: mzunguko {} haujaisha (loop did not end - check your condition)'.format(self.name))
+        symbolTable.exit(1)
+
+
+class IndexOutOfRangeException:
+    # 'fahirisi' = Swahili for "index" - reading or writing a list
+    # position that doesn't exist (negative, or past the end).
+
+    def __init__(self,arg):
+        self.name = arg
+
+    def execute(self):
+        _report('Kosa La Fahirisi: fahirisi hii katika {' +self.name +'} haipo (index out of range)')
+        symbolTable.exit(1)
+
+
+class NotAListException:
+    # 'orodha' = Swahili for "list" - trying to index/append/loop over a
+    # variable that isn't actually holding a list.
+
+    def __init__(self,arg):
+        self.name = arg
+
+    def execute(self):
+        _report('Kosa La Orodha: {' +self.name +'} si orodha (not a list)')
+        symbolTable.exit(1)
+
+
+class NotAnObjectException:
+    # 'darasa' = Swahili for "class" - trying to read/set a property or
+    # call a method on a variable that isn't actually holding an object
+    # (an instance of some darasa).
+
+    def __init__(self,arg):
+        self.name = arg
+
+    def execute(self):
+        _report('Kosa La Darasa: {' +self.name +'} si kitu (not an object)')
+        symbolTable.exit(1)
+
+
+class ImportException:
+    # 'leta' = Swahili for "bring" - used for importing a class (or one of
+    # its methods) from another file. Covers three failure shapes with one
+    # message: the file itself couldn't be found/read, the requested class
+    # isn't defined in it, or (for a selective method import) the
+    # requested method isn't defined on that class.
+
+    def __init__(self,arg):
+        self.name = arg
+
+    def execute(self):
+        _report('Kosa La Leta: {' +self.name +'} haipatikani (import failed - check the file name, class name, or method name)')
+        symbolTable.exit(1)
+
+
+Error = Errors()

--- a/ExpressionParser.py
+++ b/ExpressionParser.py
@@ -1,89 +1,187 @@
 from Objects import *
 from Logger import Log
-
-class ExpressionParser:
-    def __init__(self, args):
-        # Initialize the ExpressionParser with the given arguments (tokens)
-        self.tokens = args
         
-        # Define the operators and their corresponding Expression classes
+class ExpressionParser:
+    def __init__(self,args):
+        self.tokens = args
+
         self.operators = {
-            '+': AdditionExpression,
-            '-': SubtractionExpression,
-            '*': MultiplicationExpression,
-            '/': DivisionExpression
+
+        '+': AdditionExpression,
+        '-': SubtractionExpression,
+        '*': MultiplicationExpression,
+        '/': DivisionExpression,
+        '==': EqualsExpression,
+        '!=': NotEqualsExpression,
+        '<': LessThanExpression,
+        '>': GreaterThanExpression,
+        '<=': LessEqualExpression,
+        '>=': GreaterEqualExpression,
+        'kabisa': StrictEqualsExpression,
+        'hakika': StrictEqualsExpression
+
         }
-    
+
+
     def parse(self):
-        # Set the return value to the value of the first token in the token list
+        
+        #print("tokens before parsing: ",self.tokens)
+        
         return_val = self.tokens[0]
         
-        # Iterate through the tokens starting from the second token
-        for count, i in enumerate(self.tokens[1:]):
-            # Check if the next element in the list is a token
-            if type(i).__name__ == 'TokenObj':
-                # If the token is an operator, use its value to match the correct Expression class from self.operators
-                if i.value in self.operators.keys():
-                    return_val = self.operators[i.value]((return_val, self.tokens[count + 2]))
+        #for the first value in expression
         
+        for count,i in enumerate(self.tokens[1:]):
+            if type(i).__name__ == 'TokenObj':
+                if i.value in self.operators.keys():
+                    #print('found operator ',i.value,' in pass ',count)
+                    #print('operands: left ',return_val," right ",self.tokens[count + 2])
+                    return_val = self.operators[i.value]((return_val,self.tokens[count + 2]))
+                    #print('result object: ',return_val)
+
+        
+        #print("tokens results after parsing: ",self.tokens)
+        #print('results after parsing: ',return_val)
         return return_val
-
-
-class Expression:
-    def __init__(self, values):
-        # Initialize an Expression with the given values (left and right operands)
+                
+        
+class AdditionExpression:
+    
+    def __init__(self,values):
         self.left = values[0]
         self.right = values[1]
         
-    def evaluate(self):
-        pass
         
+    def evaluate(self):
 
-class AdditionExpression(Expression):
+        Log(self.left,'Addition operation')
+        Log(self.right,'Addition operation')
+
+        left = self.left.evaluate()
+        right = self.right.evaluate()
+
+        # Auto-stringify when mixing text with a number (e.g. "x is: " + x)
+        # instead of letting Python's str+int TypeError leak through -
+        # numeric + numeric still adds normally.
+        if isinstance(left,str) or isinstance(right,str):
+            return '{}{}'.format(left,right)
+        return left + right
+
+
+class MultiplicationExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
     def evaluate(self):
-        # Log the left and right operands for addition operation
-        Log(self.left, "Addition operation")
-        Log(self.right, "Addition operation")
-        
-        # Evaluate and return the addition of the left and right operands
-        return self.left.evaluate() + self.right.evaluate()
-    
-class SubtractionExpression(Expression):
-    def evaluate(self):
-        # Log the left and right operands for subtraction operation
-        Log(self.left, "Subtraction operation")
-        Log(self.right, "Subtraction operation")
-        
-        # Evaluate and return the subtraction of the left and right operands
-        return self.left.evaluate() - self.right.evaluate()
-    
-class MultiplicationExpression(Expression):
-    def evaluate(self):
-        # Log the left and right operands for multiplication operation
-        Log(self.left, "Multiplication operation")
-        Log(self.right, "Multiplication operation")
-        
-        # Evaluate and return the multiplication of the left and right operands
         return self.left.evaluate() * self.right.evaluate()
-    
-class DivisionExpression(Expression):
+
+
+class DivisionExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
     def evaluate(self):
-        # Log the left and right operands for division operation
-        Log(self.left, "Division operation")
-        Log(self.right, "Division operation")
-        
-        # Evaluate and return the division of the left and right operands
-        return self.left.evaluate() / self.right.evaluate()
+        # True division (e.g. 7/2 -> 3.5) since there's no separate Float
+        # type in this language yet - a whole-number result like 10/2
+        # still comes back as a plain 5 thanks to the int() cast below.
+        result = self.left.evaluate() / self.right.evaluate()
+        return int(result) if result == int(result) else result
+
+
+class SubtractionExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        Log(self.left,'Subtraction operation')
+        Log(self.right,'Subtraction operation')
+
+        return self.left.evaluate() - self.right.evaluate()
+
+
+class EqualsExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        return self.left.evaluate() == self.right.evaluate()
+
+
+class NotEqualsExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        return self.left.evaluate() != self.right.evaluate()
+
+
+class LessThanExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        return self.left.evaluate() < self.right.evaluate()
+
+
+class GreaterThanExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        return self.left.evaluate() > self.right.evaluate()
+
+
+class LessEqualExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        return self.left.evaluate() <= self.right.evaluate()
+
+
+class GreaterEqualExpression:
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        return self.left.evaluate() >= self.right.evaluate()
+
+
+class StrictEqualsExpression:
+    # 'kabisa' ("completely/exactly") - strict equality: true only if both
+    # value AND type match. Plain '==' relies on Python's own equality,
+    # where e.g. `true == 1` is True (bool is a subclass of int) - kabisa
+    # is for when that distinction matters.
+
+    def __init__(self,values):
+        self.left = values[0]
+        self.right = values[1]
+
+    def evaluate(self):
+        left = self.left.evaluate()
+        right = self.right.evaluate()
+        return type(left) == type(right) and left == right
 
 
 class ArgumentConstructorExpression:
-    def __init__(self, values):
-        pass
 
-# The code defines an `ExpressionParser` class responsible for parsing expressions using the given tokens.
-# The `parse` method of the `ExpressionParser` class iterates through the tokens, evaluates the expression, and returns the result.
-# The `ExpressionParser` class also contains an `operators` dictionary that maps operators to their corresponding `Expression` classes (`AdditionExpression`, `SubtractionExpression`, etc.).
-# The `Expression` class represents a generic expression with a left operand (`self.left`) and a right operand (`self.right`).
-# Each specific expression class (e.g., `AdditionExpression`, `SubtractionExpression`, etc.) extends the `Expression` class and overrides the `evaluate` method to perform the corresponding operation.
-# The overridden `evaluate` method logs the left and right operands for the specific operation and returns the evaluated result.
-# The `ArgumentConstructorExpression` class is empty and does not contain any specific functionality.
+    def __init__(self,values):
+        pass

--- a/LexicalParser.py
+++ b/LexicalParser.py
@@ -1,165 +1,254 @@
 import re
 import enum
+import os
 import sys
-from os.path import exists
 
-# Set holding our lexeme units. We use a set of regular expressions to match for lexemes for parsing later.
+#set holding our lexeme units
+
+# Word forms of some operators, so scripts can read more like Swahili
+# sentences instead of leaning on symbols. Normalized down to their
+# canonical symbol during tokenizing (see LexicalParser.parse) so the
+# rest of the interpreter (StatementParser, ExpressionParser) never has
+# to know these words exist - it only ever sees '>' / '<' / '='.
+WORD_OPERATORS = {
+   'inazidi': '>',   # "exceeds" -> greater than
+   'haizidi': '<',   # "does not exceed" -> less than
+   'ni': '=',        # "is" -> assignment
+   'ongeza': '+',    # "add/increase" -> addition
+   'punguza': '-',   # "reduce/decrease" -> subtraction
+   'mara': '*',      # "times" -> multiplication
+   'gawa': '/',      # "divide/share" -> division
+   'sawa': '==',     # "equal/okay" -> loose equality
+}
+
+# Word-form operators that don't map onto an existing symbol - there's no
+# '===' in Hamri's symbol set, so 'kabisa'/'hakika' ("completely/exactly",
+# "certainly/truly") keep their own name but still need to be tagged as an
+# 'operator' token (rather than 'keyword') so fetch_express() in
+# StatementParser knows to keep reading the right-hand operand after them.
+# Both are synonyms for the same strict-equality check.
+OPERATOR_KEYWORDS = {'kabisa','hakika'}
+
 class Tokens(enum.Enum):
-    keyword = r'(chapa|kama|jaza|kwisha|kwanza|eleza|aina|rudisha)'  # Regular expression for keywords
-    function = r'([a-zA-Z_][a-zA-Z0-9_]*)\s*\('
-    divider = r'(\\[|\\]|\(|\))'  # Regular expression for dividers
-    boolean = r'true|false'  # Regular expression for booleans
-    integer = r'\.\b[0-9]+|[0-9]+'  # Regular expression for integers
-    string = r'"(.*?)"|\'(.*?)\'|\b[0-9]+'  # Regular expression for strings
-    variable = r'((\'[^\']*\'|([A-Za-z_]\w*(?:\.[a-z_]\w*)*))(?!\"\')|("[^"]*"|([a-z_]\w*(?:\.[a-z_]\w*)*))(?!\"\'))'  # Regular expression for variables
-    operator = r'[\*\/\+\-\=\,]'  # Regular expression for operators
-    
+
+
+   # Word-operators are wrapped in \b so they only match as whole words -
+   # without that, 'ni' would also match inside ordinary variable names
+   # like "kani" or "nina". 'huku' (for-loop), 'kutoka' (from), 'hadi'
+   # (to/until), 'rudisha' (return), 'weka' (append to a list), 'kwenye'
+   # (into/at - the target marker for 'weka' and for-each 'huku'),
+   # 'idadi' (length of a list), 'ondoa' (remove an item from a list) and
+   # 'darasa' (class) are plain structural keywords, same idea as kama/
+   # wakati - not operators, so they aren't in WORD_OPERATORS/
+   # OPERATOR_KEYWORDS.
+   # NOTE: 'nafsi' ("self") is deliberately NOT a keyword here - unlike
+   # darasa/kama/etc it doesn't trigger its own parsing branch, it's just
+   # an ordinary variable name that happens to get auto-bound to the
+   # current instance before a method call runs (see FunctionCallStatement).
+   # Tagging it 'keyword' would stop it matching the 'variable'-typed
+   # token checks that all the dot-access parsing relies on.
+   # 'leta' ("bring") is the import keyword - 'leta X kutoka "faili"'
+   # (whole class) or 'leta x kutoka X kutoka "faili"' (one specific
+   # method of a class), reusing 'kutoka' ("from") the same way huku/ondoa
+   # already do.
+   # 'aina' ("kind/type") prints what kind of value an expression holds -
+   # a small teaching/debugging aid carried over from the original Hamri
+   # project (github.com/Hamri-language/Hamri), reimplemented properly
+   # here as a bare-expression statement (matching chapa/rudisha's own
+   # style) rather than the original's now-defunct 'aina(x)' call form.
+   keyword = r'(chapa|kama|jaza|kwisha|kwanza|eleza|sivyo|wakati|huku|\bkutoka\b|\bhadi\b|\brudisha\b|\bweka\b|\bkwenye\b|\bidadi\b|\bondoa\b|\bdarasa\b|\bleta\b|\baina\b|\binazidi\b|\bhaizidi\b|\bni\b|\bkabisa\b|\bhakika\b|\bongeza\b|\bpunguza\b|\bmara\b|\bgawa\b|\bsawa\b)'
+   # NOTE: '[' and ']' used to be written as '\\[' and '\\]' here, which in
+   # a raw string is an escaped literal BACKSLASH followed by a bracket -
+   # not the bracket itself. That silently meant square brackets were
+   # never actually tokenized at all (finditer just skipped over them).
+   # Fixed to a single backslash so they're matched like '(' and ')' are.
+   # '.' (property/method access, e.g. mtu1.jina) lives here too - it's a
+   # structural separator, not a computable operator.
+   divider = r'(\[|\]|\(|\)|\.)'
+   boolean = r'true|false'
+   integer = r'\.\b[0-9]+|[0-9]+'
+   string = r'"(.*?)"|\'(.*?)\'|\b[0-9]+'
+   # NOTE: this used to also match a trailing (?:\.[a-z_]\w*)* on both
+   # identifier alternatives, which silently fused a dotted path like
+   # "mtu1.jina" into ONE variable token instead of three ('mtu1', '.',
+   # 'jina') - nothing ever relied on that (dot access wasn't supported
+   # at all), so it's removed now that '.' is its own divider token.
+   variable = r'((\'[^\']*\'|([A-Za-z_]\w*))(?!\"\')|("[^"]*"|([a-z_]\w*))(?!\"\'))'
+   # Order matters: multi-character operators must be tried before their
+   # single-character prefixes (e.g. '==' before '=', '<=' before '<'),
+   # otherwise the regex engine greedily matches the shorter one first.
+   operator = r'(==|!=|<=|>=|<|>|\+|\-|\*|\/|\=|\,)'
+   
+
 
 class LexicalParser:
-    def __init__(self, script,flag=None):
-        # Class constructor with script (Hamri script) and an empty token_list array
-        self.script = self.read_source(script) if flag== 'f' else script.split('\n')
-        self.token_list = []
+   def __init__(self,script,from_text=False):
+      # from_text=True lets callers pass raw Hamri source code directly
+      # (e.g. from main.py's embedded sample, or a GUI text widget)
+      # instead of a file path on disk.
+      self.script = script.splitlines(keepends=True) if from_text else self.read_source(script)
+      self.token_list = []
 
-    def read_source(self, arg):
-        # Function to read in our Hamri script from source
-        script = None
-        
-        # function to return the file extension
+   def read_source(self,arg):
+      # Only reached when from_text=False - 'arg' is meant to be a path
+      # to a .ham script file on disk. Fail with a clear message instead
+      # of a raw traceback for the two most common mistakes: a typo'd
+      # path, or accidentally passing literal source text here without
+      # from_text=True.
+      if not os.path.exists(arg):
+         print('The file path you provided does not exist: {}'.format(arg))
+         sys.exit(1)
+      if not arg.endswith('.ham'):
+         print('The file you provided is not a Hamri script file (expected a .ham extension): {}'.format(arg))
+         sys.exit(1)
+      content = open(arg, "r")
+      script = content.readlines()
+      content.close()
+      return script
+      
+   def strip_comment(self,line):
+      # Everything from an unquoted '#' to the end of the line is a
+      # comment. Track quote state char-by-char so a '#' inside a string
+      # literal (e.g. chapa "Price: #1") isn't mistaken for one.
+      in_single = False
+      in_double = False
+      for idx,ch in enumerate(line):
+         if ch == "'" and not in_double:
+            in_single = not in_single
+         elif ch == '"' and not in_single:
+            in_double = not in_double
+         elif ch == '#' and not in_single and not in_double:
+            return line[:idx] + '\n'
+      return line
 
-        if exists(arg):
-            import pathlib
-            
-            if pathlib.Path(arg).suffix == '.ham':
-                content = open(arg, "r")
-                script = content.readlines()
-                content.close()
-                
-            else:
-                print('The file you provided is not a hamri script file')
-                
-                sys.exit(1)
-        else:
-            print('The file path you provided does not exist')
-            sys.exit(1)
-            
-        return script
+   def parse(self):
+      index = 0
+      all_tokens = []
 
-    def parse(self):
-        index = 0
-        all_tokens = []
+      for i,v in enumerate(self.script):
+         v = self.strip_comment(v)
 
-        for i, v in enumerate(self.script):
-            # Iterate over each line in the script
-
-            # Find all matches for the regular expressions defined in Tokens enum
-            tokens = [
-                (x.group(), x.span()[0], i) for x in re.compile(r'{}'.format('|'.join(
-                    [t.value for t in Tokens]
-                    )
-                                                                             )
-                                                                ).finditer(v)
+         tokens = [
+               (x.group(),x.span()[0],i) for x in re.compile(r'{}'.format(
+                   '|'.join(
+                      [t.value for t in Tokens]
+                      )
+                   )
+               ).finditer(v)
             ]
+         
+         for n in tokens:
+            all_tokens.append(n)
 
-            # Append the found tokens to the all_tokens list
-            for n in tokens:
-                all_tokens.append(n)
+      
+      #build one humongous re pattern to find all our lexemes
 
-        id_ = 0
-        # Assign a unique identifier to each token and store them in the token_list
-        for t_ in all_tokens:
-            for t in Tokens:
-                if self.find_token_match(t_[0], t.value):
-                    
-                    self.token_list.append(
-                        TokenObj(t.name,
-                                 t_[0].replace('"', '').replace('\'', '') if t.name == 'string' else t_[0].replace('(','') if t.name == 'function' else t_[0],
-                                 t_[1], t_[2], id_
-                                 )
-                    )
-                    break
-            id_ = id_ + 1
+      
+      #print('{}'.format('|'.join([t.value for t in Tokens])))
+      
+      #tag all tokens with a type
+      id_ = 0
+      for t_ in all_tokens:
+         for t in Tokens:
+            if self.find_token_match(t_[0],t.value):
 
-        return self
+               token_type = t.name
+               value = t_[0]
 
-    def print_tokens(self, type_='all'):
-        # Print the tokens stored in the token_list
-        for i in self.token_list:
-            if type_ == 'all':
-                print('-----------\nType: {}\nValue: {}\nLine: {}\nPosition: ({},{})\nOffset: {}\n-----------'.format(
-                    i.token_type,
-                    i.value,
-                    i.line,
-                    i.span()[0],
-                    i.span()[0] + i.size(),
-                    i.position()
-                ))
-            else:
-                if type_ == i.token_type:
-                    print('-----------\nType: {}\nValue: {}\n-----------'.format(
-                        i.token_type,
-                        i.value, i.start,
-                        i.start + i.len_
-                    ))
+               # Word-form operators (inazidi/haizidi/ni) tag as 'keyword'
+               # like any other reserved word, but the rest of the
+               # interpreter expects to see the symbol ('>','<','=') it
+               # already knows how to handle - so swap it in here, once,
+               # at the source.
+               if value in WORD_OPERATORS:
+                  token_type = 'operator'
+                  value = WORD_OPERATORS[value]
+               elif value in OPERATOR_KEYWORDS:
+                  token_type = 'operator'
 
-    def count_tokens(self):
-        # Count the number of tokens in the token_list and print the count
-        count = len(self.token_list)
-        print('-----------\nTokens: {}\n-----------'.format(count))
-        return count
+               self.token_list.append(
+                  TokenObj(token_type,
+                        value.replace('"','').replace('\'','') if token_type == 'string' else value,#remove string quotes statements
+                        t_[1],t_[2],id_
+                        )
+                  )
+               break
+         id_ = id_+1
+                          
+            
+      return self
+   
+   def print_tokens(self,type_ = 'all'):
+      for i in self.token_list:
+         if type_ == 'all':
+            print('-----------\nType: {}\nValue: {}\nLine: {}\nPosition: ({},{})\nOffset: {}\n-----------'.format(
+               i.token_type,
+               i.value,
+               i.line,
+               i.span()[0],
+               i.span()[0]+i.size(),
+               i.position()
+            ))
+         else:
+            if type_ == i.token_type:
+               print('-----------\nType: {}\nValue: {}\n-----------'.format(
+                  i.token_type,
+                  i.value,i.start,
+                  i.start+i.len_))
 
-    def find_token_match(self, search_str, pat_):
-        # Check if the search string matches the given pattern
-        pattern = re.compile(pat_)
-        return_match = True if len(pattern.findall(search_str)) > 0 else False
+         
+   def count_tokens(self):
+      count = len(self.token_list)
+      print('-----------\nTokens: {}\n-----------'.format(count))
+      return count
+      
+   def find_token_match(self,search_str,pat_):
 
-        # Strict check to make sure integers in strings are avoided
-        if pat_ == Tokens.integer.value:
-            if len(re.compile(r'[\"\']').findall(search_str)) > 0:
-                return_match = False
+      pattern = re.compile(pat_)
 
-        return return_match
+      # Must match the WHOLE extracted token, not just find pat_ somewhere
+      # inside it - otherwise a string like "(you are an adult)" gets
+      # misclassified as a divider just because it contains parentheses.
+      return_match = pattern.fullmatch(search_str) is not None
 
 
+      #strict check for to make sure integers in strings are avoided
+      if pat_ == Tokens.integer.value:
+         
+         if len(re.compile(r'[\"\']').findall(search_str))>0:
+            return_match = False
+      
+      return return_match
+  
+
+            
+
+   
 class TokenObj:
-    def __init__(self, token_type, value, start, line, offset):
-        # Initialize a token object with its properties
-        self.token_type = token_type
-        self.value = value
-        self.line = line
-        self.start = start
-        self.offset = offset
-        self.len_ = len(self.value)
+   def __init__(self, token_type, value,start,line,offset):
+      self.token_type = token_type
+      self.value = value
+      self.line = line
+      self.start = start
+      self.offset = offset
+      self.len_ = len(self.value)
+   def value(self):
+      return self.value
+   
+   def position(self):
+      return self.offset
+   
+   def type(self):
+      return self.token_type
+   
+   def size(self):
+      return self.len_
 
-    def value(self):
-        #the value of the actual token
-        return self.value
-
-    def position(self):
-        #the offset of the token in the script
-        return self.offset
-
-    def type(self):
-        #the type of the token as matched by the various regex expressions
-        return self.token_type
-
-    def size(self):
-        #the size (count) of the token type
-        return self.len_
-
-    def span(self):
-        #a tuple representing the start and end positions of the token
-        return (self.start, self.start + self.len_)
-
-    def evaluate(self):
-        return self
-
-
-
-##- This code defines a lexical parser for the Hamri programming language. 
-##- It uses regular expressions defined in the 'Tokens' enum to match and extract different lexemes from the Hamri script. 
-##- The 'LexicalParser' class reads the source script, parses it line by line, and identifies the tokens based on the regular expressions. 
-##- The tokens are stored in the 'token_list' as 'TokenObj' instances. 
-##- The code also provides methods to print the tokens, count the tokens, and find token matches. 
-##- The 'TokenObj' class represents a token object with various properties to store information about the token.
-
+   def span(self):
+      return (self.start,self.start+self.len_)
+   
+   def evaluate(self):
+      return self
+         
+ 
+   

--- a/Notepad.py
+++ b/Notepad.py
@@ -9,8 +9,13 @@ import os
 
 from LexicalParser import LexicalParser
 from StatementParser import StatementParser
-from Console import console
+from SymbolTable import symbolTable
 from Logger import Logs,LogKeys
+
+# NOTE: Console.py's singleton `console` (previously imported here) is no
+# longer used - StatementParser now takes the console widget directly as
+# an argument to .parse(), instead of routing print/error output through
+# a separate global. See __execute() below.
 
 class CustomText(Text):
     def __init__(self, *args, **kwargs):
@@ -24,7 +29,19 @@ class CustomText(Text):
 
     def _proxy(self, command, *args):
         cmd = (self._orig, command) + args
-        result = self.tk.call(cmd)
+        try:
+            result = self.tk.call(cmd)
+        except tk.TclError:
+            # Benign Tcl-level errors happen here routinely - e.g. a
+            # <<Paste>> triggers "delete sel.first sel.last" even when
+            # nothing is selected, which Tcl reports as an error ("text
+            # doesn't contain any characters tagged with sel") rather than
+            # just a no-op. Uncaught, that exception propagates straight
+            # out of Tk's mainloop and kills the whole application instead
+            # of just skipping the no-op delete. Swallow it here and let
+            # the rest of the command (e.g. the actual insert half of a
+            # paste) proceed normally.
+            return ""
 
         if command in ("insert", "delete", "replace"):
             self.event_generate("<<TextModified>>")
@@ -54,6 +71,21 @@ class Notepad:
         self.__thisTextArea = CustomText(self.__thisCodeFrame, font=("Courier", 12, "normal"))
         self.__thisTextArea.pack(side=TOP, fill='both', expand=1)
 
+        # A visible in-window toolbar with a Run button - on macOS the Menu
+        # bar below is drawn in the system menu bar at the top of the
+        # screen (not inside the window itself), and a Tk app launched
+        # from a terminal (rather than a real .app bundle) doesn't always
+        # grab menu focus reliably. This button guarantees there's always
+        # a way to run the script without depending on that.
+        self.__thisToolbar = ttk.Frame(self.__thisCodeFrame)
+        self.__thisToolbar.pack(side=TOP, fill='x')
+        self.__thisRunButton = ttk.Button(self.__thisToolbar, text="Run ▶", command=self.__execute)
+        self.__thisRunButton.pack(side=LEFT, padx=4, pady=4)
+        self.__thisClearEditorButton = ttk.Button(self.__thisToolbar, text="Clear Editor", command=self.__clearEditor)
+        self.__thisClearEditorButton.pack(side=LEFT, padx=4, pady=4)
+        self.__thisClearConsoleButton = ttk.Button(self.__thisToolbar, text="Clear Console", command=self.__clearConsole)
+        self.__thisClearConsoleButton.pack(side=LEFT, padx=4, pady=4)
+
         # Create the console for displaying output
         self.__thisConsole = CustomText(self.__thisCodeFrame, font=("Courier", 12, "normal"), height=18, bg="black", fg="white")
         self.__thisConsole.pack(side=TOP, fill='x')
@@ -68,6 +100,9 @@ class Notepad:
         self.__thisFileMenu.add_command(label="Open", command=self.__openFile)
         self.__thisFileMenu.add_command(label="Save", command=self.__saveFile)
         self.__thisFileMenu.add_command(label="Execute", command=self.__execute)
+        self.__thisFileMenu.add_separator()
+        self.__thisFileMenu.add_command(label="Clear Editor", command=self.__clearEditor)
+        self.__thisFileMenu.add_command(label="Clear Console", command=self.__clearConsole)
         self.__thisFileMenu.add_separator()
         self.__thisFileMenu.add_command(label="Exit", command=self.__quitApplication)
         self.__thisMenuBar.add_cascade(label="File", menu=self.__thisFileMenu)
@@ -88,6 +123,12 @@ class Notepad:
         # Bind events to the text area
         self.__thisTextArea.bind("<<TextModified>>", self.__generateTags)
 
+        # Keyboard shortcut for running the script (Cmd+R on macOS,
+        # Ctrl+R elsewhere) as a second fallback alongside the Run button,
+        # independent of the File menu / menu bar entirely.
+        self.__root.bind_all("<Command-r>", lambda event: self.__execute())
+        self.__root.bind_all("<Control-r>", lambda event: self.__execute())
+
     def __generateTags(self, event=None):
         """Generates tags for syntax highlighting"""
         # Clear existing tags
@@ -96,9 +137,12 @@ class Notepad:
         self.__thisTextArea.tag_delete("Token.Operator")
         self.__thisTextArea.tag_delete("Token.Literal")
 
-        # Parse code and generate tokens
+        # Parse code and generate tokens. from_text=True is required here -
+        # without it, LexicalParser treats its argument as a *file path* by
+        # default (see main.py) rather than literal source text, which
+        # would raise on every keystroke since this text isn't a real file.
         code = self.__thisTextArea.get("1.0", "end-1c")
-        lexer = LexicalParser(code).parse()
+        lexer = LexicalParser(code, from_text=True).parse()
         self.__Tokens = lexer.token_list
         
 
@@ -167,20 +211,31 @@ class Notepad:
         """Execute the code and display output in the console"""
         code = self.__thisTextArea.get("1.0", "end-1c")
 
-        # Perform lexical analysis
-        lexer = LexicalParser(code).parse()
+        # Reset the interpreter's global state before each run, so a
+        # previous Execute click's variables/classes/functions don't leak
+        # into this one.
+        symbolTable.reset()
+
+        # Perform lexical analysis (from_text=True - see __generateTags)
+        lexer = LexicalParser(code, from_text=True).parse()
         tokens = lexer.token_list
 
-        # Perform statement parsing
-        statements = StatementParser(tokens).parse()
-        
-        #pass our console object to the runtime sequence and clear it
-        
-        console.use_console(self.__thisConsole)
+        # Perform statement parsing, passing the console Text widget
+        # straight in - StatementParser routes all chapa/error output to
+        # whatever's passed here (or falls back to a bare print() if
+        # nothing is), rather than through the old Console.py singleton.
+        statements = StatementParser(tokens).parse(self.__thisConsole)
 
-        # Execute the statements and capture the output
-        
+        # Execute the parsed statements
         result = statements.execute()
+
+    def __clearEditor(self):
+        """Clear all text out of the code editor"""
+        self.__thisTextArea.delete("1.0", "end")
+
+    def __clearConsole(self):
+        """Clear all output out of the console pane"""
+        self.__thisConsole.delete("1.0", "end")
 
     def __quitApplication(self):
         """Quit the application"""

--- a/Objects.py
+++ b/Objects.py
@@ -1,84 +1,112 @@
-from SymbolTable import symbolTable  # Importing the symbolTable module
-from Errors import Error  # Importing the Error module
+from SymbolTable import symbolTable
 
-# The Object class represents a generic object.
+from Errors import Error
+
 class Object:
-    def __init__(self, value):
-        self.token = value  # Initialize the token attribute with the provided value
-        
-    def return_type(self):
-        pass
-        
+    def __init__(self,value):
+        self.token = value
         
     def cast(self):
-        casted_val = self.token  # Start with the original token value
+        casted_val = self.token
         data_types = {
-            'string': Str,  # Mapping the string data type to the Str class
-            'integer': Int,  # Mapping the integer data type to the Int class
-            'boolean': Bool,  # Mapping the boolean data type to the Bool class
-            'variable': Var  # Mapping the variable data type to the Var class
+        
+        'string':Str,
+        'integer':Int,
+        'boolean':Bool,
+        'variable':Var
+        
         }
         if self.token.token_type in data_types.keys():
-            # If the token's type is in the data_types dictionary, create an instance of the corresponding class
             casted_val = data_types[self.token.token_type](self.token.value)
+            
+        return casted_val
+            
+        
+        
+        
 
-        return casted_val  # Return the casted value
-
-
-# The Var class represents a variable object.
 class Var(Object):
-    def __init__(self, value):
-        self.mode = 1 if type(value).__name__ == 'tuple' else 2  # Determine the mode based on the type of the value
+    def __init__(self,value):
+
+        self.mode = 1 if type(value).__name__ == 'tuple' else 2
+
 
         if self.mode == 1:
-            # If mode is 1, it means the value is a tuple containing name, value, and scope
-            self.name, self.value, self.scope = value
+            # A 4th tuple element ('qualify') is optional - True means
+            # this is an ordinary user-level local variable (from a plain
+            # '=' assignment, or a huku/jaza-created variable) that should
+            # be isolated to whichever function/method call is currently
+            # executing (see SymbolTable.write_local). Callers that
+            # already pass a fully call-qualified name themselves
+            # (function parameter binding, 'nafsi' binding, parameter
+            # placeholder creation) omit it / leave it False, since
+            # qualifying an already-qualified key again would double it up.
+            if len(value) == 4:
+                self.name,self.value,self.scope,self.qualify = value
+            else:
+                self.name,self.value,self.scope = value
+                self.qualify = False
+
         else:
-            self.name = value  # If mode is 2, it means the value is only the variable name
-            
-    def return_type(self):
-        return '<\'Anwani\'>'
+            self.name = value
+
+
 
     def evaluate(self):
-        result = False  # Initialize the result variable as False
+
+        result = False
 
         if self.mode == 1:
-            # If mode is 1, it means the variable is being assigned a value
-            symbolTable.table['variables'][self.scope][self.name] = self.value  # Assign the value to the variable
-            result = True  # Set the result as True, indicating successful assignment
+            # Evaluate the right-hand side NOW and store the plain result
+            # (wrapped in Literal), not the unevaluated expression object.
+            # Storing the raw expression broke self-referential assignment
+            # (e.g. "i = i + 1"): the stored expression for 'i' would
+            # itself contain a reference to 'i', so reading it back later
+            # tried to evaluate 'i' in terms of itself forever - fine for
+            # one-shot code, but fatal for any loop counter.
+            # Not every caller passes an expression Object here - function
+            # parameter placeholders assign a plain '' string directly -
+            # so only call .evaluate() when there's actually one to call.
+            evaluated = self.value.evaluate() if hasattr(self.value,'evaluate') else self.value
+            if self.qualify and self.scope == 'local':
+                symbolTable.write_local(self.name,Literal(evaluated))
+            else:
+                symbolTable.table['variables'][self.scope][self.name] = Literal(evaluated)
+            result = True
         else:
-            result = symbolTable.fetch_variable(self.name)  # Fetch the value of the variable from the symbol table
+            
+            result = symbolTable.fetch_variable(self.name)
             if result:
                 result = symbolTable.fetch_variable(self.name).evaluate()
-                # If the variable is found, evaluate its value recursively
             else:
-                Error.throwException('anwani', self.name)
-                # If the variable is not found, throw an exception and set the result as False
+                Error.throwException('anwani',self.name)            
+                result = False
+        
+        return result
 
-        return result  # Return the result
-
-
-# The Int class represents an integer object.
 class Int(Object):
     def evaluate(self):
-        return int(self.token)  # Return the integer value of the token
+        
+        return int(self.token)
 
-
-# The Str class represents a string object.
 class Str(Object):
     def evaluate(self):
-        return '{}'.format(self.token)  # Return the string value of the token
+        return '{}'.format(self.token)
 
-
-# The Bool class represents a boolean object.
 class Bool(Object):
     def evaluate(self):
-        return bool(self.token.capitalize())  # Return the boolean value of the token
+        # bool(str) in Python is True for ANY non-empty string - including
+        # "false" itself - so this used to make every boolean true.
+        return str(self.token).strip().lower() == 'true'
 
+class Literal(Object):
+    # Wraps an already-evaluated plain Python value (bool/int/float/str)
+    # so it can be stored in a variable and re-read later through the
+    # same .evaluate() interface as every other Object, without needing
+    # to re-parse or re-cast it from text.
+    def evaluate(self):
+        return self.token
+    
+    
 
-# The code above defines several classes for different types of objects, such as variables, integers, strings, and booleans.
-# These classes inherit from the Object class and provide the evaluate method, which returns the evaluated value of the object.
-# The Var class handles variable assignments and retrieval, the Int class converts the token to an integer, the Str class converts the token to a string,
-# and the Bool class converts the token to a boolean value.
-# The Object class also provides the cast method, which allows for type casting of objects.
 

--- a/README.md
+++ b/README.md
@@ -1,67 +1,656 @@
 # Hamri
 
-Welcome to the Hamri programming language code base.
-Hamri is initially written in Python for ease of readability by contributors
-We are however transpiling the code base to c/c++ soon. 
+Hamri is a small, Swahili-keyword programming language, written in pure
+Python for ease of readability by contributors. We are however
+transpiling the code base to C/C++ soon.
 
+This README is a full language reference in addition to run
+instructions — everything below runs directly with the interpreter in
+this repo, no external dependencies beyond the Python standard library
+(Tkinter is only needed for the optional desktop IDE).
 
-To run the code:
+## Running Hamri
 
-1. Clone the repository to your computer
+1. Clone the repository:
 
         git clone https://github.com/Hamri-language/Hamri.git
 
-2. Add an empty file. Name it whatever you wish but make sure to give it the extension ' .ham ' . Paste the sample code into the file and save it.
+2. Run the built-in demo script, or your own `.ham` file, straight from
+   the console:
 
+        python3 main.py                       # runs the sample bundled in main.py
+        python3 main.py path/to/script.ham    # runs a script file of your own
 
+3. Or use the provided desktop IDE (Tkinter):
 
-        
-        kwanza
-        
-            hamri_v = "Hamri v1.02"
+        python3 Notepad.py
 
-            eleza sayHi(name)
+   Write or open a script in the text area, then use the "Run ▶" button
+   (or `Cmd+R` / `Ctrl+R`, or File > Execute) to run it — output appears
+   in the console pane below. "Clear Editor" and "Clear Console" (also
+   in the File menu) reset either pane.
 
-                chapa "Hello world. " + "I am " + name
+   Tkinter isn't part of the Python standard install on every platform.
+   If `python3 Notepad.py` fails with `ModuleNotFoundError: No module
+   named '_tkinter'`, install your platform's Tk bindings (e.g. on
+   macOS with Homebrew Python: `brew install python-tk@<your version>`).
 
-            kwisha
+See CHANGELOG.md for the full history of language features and fixes on
+top of the original implementation.
 
+## Getting started
 
-            sayHi(hamri_v)
+Every Hamri program needs a `kwanza ... kwisha` block — this is the
+required entry point. Code written outside it (such as function or
+class definitions) is parsed but never runs on its own; only what's
+inside `kwanza` executes.
 
-            chapa 10 / 2
+```
+kwanza
+    chapa "Habari, Dunia!"
+kwisha
+```
 
-            aina(hamri_v)
-        
-        kwisha
+## Keywords
 
+Every reserved word in Hamri is Swahili. Some are structural (they mark
+the start or end of a block); a few are word forms of an operator, so a
+condition or assignment can read like a sentence instead of leaning on
+symbols.
 
+| Keyword | Swahili meaning | What it does in Hamri |
+|---|---|---|
+| `kwanza` | first | Opens the required main block — only code inside `kwanza ... kwisha` runs automatically |
+| `kwisha` | finished, the end | Closes any open block: `kwanza`, `kama`, `eleza`, `wakati`, `huku`, or `darasa` |
+| `chapa` | print, stamp | Prints a value to the console |
+| `jaza` | fill | Prompts for input (via the terminal) and stores it into a variable |
+| `eleza` | explain | Defines a function or class method |
+| `kama` | if, like | Starts a conditional block |
+| `sivyo` | otherwise, not so | Else branch of a `kama` block |
+| `wakati` | while, time | Starts a loop that repeats while its condition is true |
+| `huku` | during, while | Starts a counted for-loop (`huku i kutoka 0 hadi 5`) or a for-each loop (`huku item kwenye orodha`) |
+| `kutoka` | from | Marks the starting value in a `huku` range, or the source file in a `leta` import |
+| `hadi` | to, until | Marks the (exclusive) ending value in a `huku` range |
+| `rudisha` | return, give back | Returns a value to the caller and exits the function immediately |
+| `ni` | is | Word form of `=` — e.g. `umri ni 20` |
+| `inazidi` | exceeds | Word form of `>` |
+| `haizidi` | does not exceed | Word form of `<` |
+| `sawa` | equal, okay | Word form of `==` (loose equality) |
+| `kabisa` / `hakika` | completely / certainly | Strict equality — true only if both value *and* type match |
+| `ongeza` | add, increase | Word form of `+` |
+| `punguza` | reduce, decrease | Word form of `-` |
+| `mara` | times | Word form of `*` |
+| `gawa` | divide, share | Word form of `/` |
+| `weka` | put, place | Appends a value to a list — `weka <value> kwenye <list>` |
+| `kwenye` | into, at | Marks the target list for `weka`, or the list being looped over in a for-each `huku` |
+| `idadi` | count, number | Length of a list — `n = idadi orodha` |
+| `ondoa` | remove | Removes an item from a list by position — `ondoa <index> kutoka <list>` |
+| `darasa` | class | Defines a class — `darasa Jina ... kwisha` |
+| `leta` | bring | Imports a class, or one of its methods, from another file |
+| `aina` | kind, type | Prints what kind of value an expression holds — `aina umri` |
 
+`nafsi` ("self", used inside a method to refer to the current object) is
+**not** a reserved keyword the way the others above are — it's an
+ordinary variable name that Hamri automatically binds to the current
+instance before a method runs. See [Classes](#classes-darasa) below.
 
-Add the file's path to the 'path_' variable in the 'main.py' file
+Word operators and symbol operators can be mixed freely in the same
+script — `umri ni 20` and `umri = 20` do exactly the same thing.
 
-        path_ = 'path/to/your/file.ham'
+## Variables & types
 
-4. Run the script as you would do any other python program from console
+Assign with `=`. There's no keyword needed to declare a variable — just
+assign it.
 
-        $ python main.py
+```
+kwanza
+    name = "Amara"
+    age = 25
+    is_member = true
+kwisha
+```
 
-5. You can also run Hamri from the provided simple IDE.
-        
-        $ python Notepad.py
+| Type | Example | Notes |
+|---|---|---|
+| Text | `"hello"` or `'hello'` | Double or single quotes |
+| Whole number | `10` | No separate float type — see Operators below for what division returns |
+| Boolean | `true` / `false` | Lowercase only |
 
-Note: 
-    You can also run these scripts from your favourite code editor. 
+Check what kind of value something is with `aina` ("kind/type") —
+prints `namba` (number), `neno` (text), `boolean`, `orodha` (list), or
+the class name itself for an object:
 
-The code is properly commented and annotated . Happy coding !!!
+```
+kwanza
+    age = 25
+    aina age
 
+    name = "Amara"
+    aina name
+kwisha
+```
 
-Follow us on our socials
+## Printing: `chapa`
 
-  Instagram - https://wwww.instagram.com/hamri.lang
-  
-  Facebook - https://www.facebook.com/hamri.lang
-  
-  linkedIn - https://www.linkedin.com/company/hamri-foundation
-  
-  email - hello@hamri.org
+`chapa` prints a value or expression, including numbers, text,
+booleans, and variables.
+
+```
+kwanza
+    chapa "Hello world"
+    x = 5
+    chapa x
+    chapa "x is: " + x
+kwisha
+```
+
+## Input: `jaza`
+
+`jaza` asks the user for input at the terminal and stores the result in
+a variable. Separate the prompt text and the variable name with a
+comma.
+
+```
+kwanza
+    jaza "Enter your name: ", jina
+    chapa "Habari, " + jina
+kwisha
+```
+
+> If the typed input is a plain whole number (e.g. `25`, or a negative
+> like `-3`), it's automatically stored as a number so it can be used
+> directly in comparisons and arithmetic. Anything else — including a
+> decimal like `3.5` — is stored as text. `jaza` always reads from the
+> terminal via a standard input prompt, even when running through the
+> desktop Notepad IDE — it doesn't currently pop up its own input
+> dialog there, so keep an eye on the terminal you launched
+> `Notepad.py` from if a script uses it.
+
+## Conditionals: `kama`
+
+Runs a block only if the condition is true. Add `sivyo` ("otherwise")
+for what should happen when it's false — still just one `kwisha` closes
+the whole thing.
+
+```
+kwanza
+    umri = 20
+    kama umri > 17
+        chapa "Mtu mzima (adult)"
+    sivyo
+        chapa "Kijana (minor)"
+    kwisha
+kwisha
+```
+
+| Operator | Word form | Meaning |
+|---|---|---|
+| `==` | | equal to |
+| `!=` | | not equal to |
+| `<` | `haizidi` | less than |
+| `>` | `inazidi` | greater than |
+| `<=` | | less than or equal to |
+| `>=` | | greater than or equal to |
+| | `kabisa` / `hakika` | strict equality — value *and* type must match |
+
+`kama` blocks can be nested inside functions, inside loops, and inside
+each other.
+
+## Loops: `wakati`
+
+`wakati` ("while") repeats its block for as long as the condition stays
+true, re-checking it before every pass. Remember to change something
+inside the loop that will eventually make the condition false.
+
+```
+kwanza
+    i = 0
+    wakati i < 5
+        chapa i
+        i = i + 1
+    kwisha
+kwisha
+```
+
+> If a loop's condition never becomes false, it stops itself
+> automatically after 100,000 passes with a `Kosa La Mzunguko` error,
+> rather than hanging forever. If you see that error, double-check that
+> your loop is actually updating the variable the condition depends on.
+
+## For loops: `huku`
+
+`huku` ("during/while") counts a variable through a range, no
+parentheses needed: `huku <var> kutoka <start> hadi <end>`. `kutoka`
+means "from" and `hadi` means "to/until" — the loop variable is created
+for you and runs from `start` up to, but not including, `end` (just
+like Python's `range()`).
+
+```
+kwanza
+    huku i kutoka 0 hadi 5
+        chapa i
+    kwisha
+kwisha
+```
+
+If `end` is smaller than `start`, `huku` counts down instead:
+
+```
+kwanza
+    huku i kutoka 5 hadi 0
+        chapa i
+    kwisha
+kwisha
+```
+
+The `start` and `end` bounds can be any expression, not just literal
+numbers — variables, arithmetic, or a mix. `huku` shares the same
+100,000-iteration safety cap (`Kosa La Mzunguko`) as `wakati`, and can
+be nested inside `kama`, `wakati`, functions, or other `huku` loops.
+
+## Functions: `eleza`
+
+Define a function with `eleza name(params) ... kwisha`. Parentheses are
+required even with no parameters. Functions can be defined either
+inside or outside the `kwanza` block; call them with
+`name(arguments)`.
+
+```
+eleza add(a, b)
+    chapa a + b
+kwisha
+
+kwanza
+    add(3, 4)
+kwisha
+```
+
+> Calling a function that was never defined with `eleza` produces a
+> clear error (`Kosa La Kazi`) rather than crashing.
+
+## Returning values: `rudisha`
+
+`rudisha` ("return") hands a value back to whatever called the function
+and stops the function immediately — nothing after it in that function
+runs, even if it's nested inside a `kama`, `wakati`, or `huku`. A bare
+`rudisha` with no value is useful on its own as an early exit (a guard
+clause).
+
+```
+eleza square(x)
+    rudisha x mara x
+kwisha
+
+eleza safe_divide(a, b)
+    kama b sawa 0
+        chapa "Can't divide by zero"
+        rudisha
+    kwisha
+    rudisha a gawa b
+kwisha
+
+kwanza
+    result = square(5)
+    chapa result
+
+    chapa safe_divide(10, 2)
+kwisha
+```
+
+> A function's return value can be captured with `x = name(args)`,
+> printed directly with `chapa name(args)`, or combined inline with an
+> operator (`chapa square(2) + 1`) anywhere in a larger expression. If a
+> function never hits a `rudisha`, calling it this way gives back
+> nothing meaningful.
+
+## Operators
+
+| Operator | Word form | Meaning | Notes |
+|---|---|---|---|
+| `=` | `ni` | Assignment | `umri = 20` and `umri ni 20` are identical |
+| `+` | `ongeza` | Addition, or joining text | `"age: " + 5` works — text and numbers are joined automatically |
+| `-` | `punguza` | Subtraction | |
+| `*` | `mara` | Multiplication | |
+| `/` | `gawa` | Division | Returns a whole number when it divides evenly (`10/2` → `5`), otherwise a decimal (`7/2` → `3.5`) |
+| `==` | `sawa` | Loose equality | `1 == true` is true — numbers and booleans compare loosely |
+| | `kabisa` / `hakika` | Strict equality | True only if value *and* type match — `1 kabisa true` is false, unlike `==`/`sawa` |
+
+## Comments
+
+Anything after a `#` on a line is ignored — use it for notes to
+yourself or to explain what the code does. A `#` inside a text string
+is left alone.
+
+```
+kwanza
+    # this line is ignored entirely
+    chapa "Price: #1"  # this trailing note is stripped, the string isn't
+kwisha
+```
+
+## Lists: `orodha`
+
+A list holds an ordered collection of values, written with square
+brackets and commas: `[1, 2, 3]`. Items can be any mix of text,
+numbers, or booleans, and are numbered starting at `0`.
+
+```
+kwanza
+    orodha = [10, 20, 30]
+    chapa orodha
+    chapa orodha[0]
+kwisha
+```
+
+Update an existing item in place by assigning to its position:
+
+```
+kwanza
+    orodha = [10, 20, 30]
+    orodha[1] = 99
+    chapa orodha
+kwisha
+```
+
+Add an item to the end of a list with `weka <value> kwenye <list>`
+("put value into list"), and find out how many items a list has with
+`idadi <list>` ("count/number of list"):
+
+```
+kwanza
+    orodha = [10, 20, 30]
+    weka 40 kwenye orodha
+    chapa idadi orodha
+kwisha
+```
+
+Loop over every item in a list directly with
+`huku <var> kwenye <list>` ("for var in list") — no index bookkeeping
+needed. This is a separate form of `huku` from the counted
+`kutoka`/`hadi` range covered earlier; `idadi` also pairs naturally with
+the counted form if you need the index itself:
+
+```
+kwanza
+    orodha = ["chai", "kahawa", "maji"]
+
+    huku kinywaji kwenye orodha
+        chapa kinywaji
+    kwisha
+
+    huku i kutoka 0 hadi idadi orodha
+        chapa orodha[i]
+    kwisha
+kwisha
+```
+
+Remove an item by position with `ondoa <i> kutoka <list>` ("remove i
+from list") — the remaining items shift down to fill the gap:
+
+```
+kwanza
+    orodha = [10, 20, 30]
+    ondoa 1 kutoka orodha
+    chapa orodha
+kwisha
+```
+
+Lists can nest — an item inside `[...]` can be another list literal, to
+any depth:
+
+```
+kwanza
+    matrix = [[1, 2], [3, 4]]
+    chapa matrix
+
+    row = matrix[0]
+    chapa row
+    chapa row[1]
+kwisha
+```
+
+> A list variable can also come from a function's return value
+> (`orodha = make_list()`) or be built from other variables
+> (`[a, b, c]`). Indexing, appending, removing, and length all check
+> that the variable is actually a list first, and that an index is in
+> range, reporting `Kosa La Orodha` or `Kosa La Fahirisi` instead of
+> crashing. Reaching into a nested list takes two steps, not one —
+> `row = matrix[0]` then `row[1]`, rather than `matrix[0][1]` directly.
+
+## Classes: `darasa`
+
+`darasa` ("class") groups methods (functions) that belong together and
+can be instantiated as objects. A class body contains only `eleza`
+method definitions — there's no way to declare a plain property
+directly in the class body. Instead, properties are set on an instance
+from inside a method, using `nafsi` ("self"), which Hamri automatically
+binds to the current object every time a method runs.
+
+```
+darasa Mtu
+    eleza jenga(jina)
+        nafsi.jina = jina
+    kwisha
+
+    eleza salamu()
+        chapa "Habari, mimi ni " + nafsi.jina
+    kwisha
+kwisha
+
+kwanza
+    mtu1 = Mtu("Amara")
+    mtu1.salamu()
+kwisha
+```
+
+A method named `jenga` ("build") is treated as the constructor — if a
+class defines one, it runs automatically as soon as the class is
+instantiated (`Mtu("Amara")`), with whatever arguments were passed to
+the call. A class doesn't need a `jenga` at all; without one, `Mtu()`
+just creates a bare instance with no properties set yet.
+
+From outside the class, dot notation reads a property or calls a
+method on an instance. Each instance keeps its own separate set of
+properties — two objects made from the same class never share state. A
+method can also call another method on the same object via `nafsi`:
+
+```
+darasa Counter
+    eleza jenga()
+        nafsi.count = 0
+    kwisha
+
+    eleza increment()
+        nafsi.count = nafsi.count ongeza 1
+        rudisha nafsi.count
+    kwisha
+kwisha
+
+kwanza
+    counter1 = Counter()
+    chapa counter1.increment()
+    chapa counter1.increment()
+    chapa counter1.count
+kwisha
+```
+
+Instances work like any other value — they can be stored in a list,
+including a list built directly from constructor calls, and looped over
+with `huku ... kwenye`:
+
+```
+darasa Mnyama
+    eleza jenga(jina, sauti)
+        nafsi.jina = jina
+        nafsi.sauti = sauti
+    kwisha
+
+    eleza tangaza()
+        rudisha nafsi.jina + " anasema " + nafsi.sauti
+    kwisha
+kwisha
+
+kwanza
+    wanyama = [Mnyama("Simba", "Ngurumo"), Mnyama("Paka", "Meow")]
+    huku mnyama kwenye wanyama
+        chapa mnyama.tangaza()
+    kwisha
+kwisha
+```
+
+> Property reads and method calls can be combined inline with an
+> operator, just like a function call or an indexed read —
+> `chapa "Habari, " + nafsi.jina` and
+> `nafsi.count = nafsi.count ongeza 1` both work as written, no
+> intermediate variable needed. There's no inheritance yet (one
+> `darasa` can't extend another) and no static/shared class variables —
+> every property lives on one specific instance.
+
+## Modules: `leta`
+
+`leta` ("bring") imports a class — or one specific method of a class —
+from another `.ham` file on disk.
+
+```
+# mtu.ham
+darasa Mtu
+    eleza jenga(jina)
+        nafsi.jina = jina
+    kwisha
+
+    eleza salamu()
+        rudisha "Habari, mimi ni " + nafsi.jina
+    kwisha
+
+    eleza mraba(n)
+        rudisha n mara n
+    kwisha
+kwisha
+```
+
+From another file, bring the whole class in with `kutoka` ("from"):
+
+```
+leta Mtu kutoka "mtu.ham"
+
+kwanza
+    mtu1 = Mtu("Amara")
+    chapa mtu1.salamu()
+kwisha
+```
+
+Import more than one class from the same file in a single statement
+with a comma list: `leta Mtu, Mnyama kutoka "mtu.ham"`.
+
+You can also import just one specific method of a class, without
+pulling in the whole thing, by naming the class as well:
+`leta <method> kutoka <Class> kutoka "<faili>"`. This works standalone
+(no instance needed) as long as the method never reaches for `nafsi`:
+
+```
+leta mraba kutoka Mtu kutoka "mtu.ham"
+
+kwanza
+    chapa mraba(5)
+kwisha
+```
+
+> A method imported this way still has access to its own parameters as
+> normal, but has no instance to bind `nafsi` to — calling it if its
+> body still uses `nafsi.anything` fails with `Kosa La Anwani`, the
+> same as referencing any other undefined variable. Also worth knowing:
+> importing a file that happens to have its own `kwanza` block (e.g.
+> one written to be run standalone too) never executes that block as a
+> side effect — only its `darasa`/`eleza` definitions come along.
+> There's no renaming on import (a class or method always keeps the
+> name it was defined with) and no per-scope isolation — once imported,
+> a class is available everywhere in the rest of the file, not just
+> after the `leta` line.
+
+## Error messages
+
+Hamri reports runtime errors in Swahili and stops the script (exit code
+1) rather than continuing silently.
+
+| Message | Cause |
+|---|---|
+| `Kosa La Anwani` (Address Error) | Referenced a variable that was never assigned |
+| `Kosa La Kazi` (Function Error) | Called a function that was never defined with `eleza`, or a method that doesn't exist on a class |
+| `Kosa La Mzunguko` (Loop Error) | A `wakati`/`huku` loop ran past 100,000 iterations without its condition becoming false |
+| `Kosa La Orodha` (List Error) | Tried to index, update, append to, loop over, or measure the length of a variable that isn't a list |
+| `Kosa La Fahirisi` (Index Error) | Used a list position that's negative or past the end of the list |
+| `Kosa La Darasa` (Class Error) | Tried to read a property or call a method on a variable that isn't an object (an instance of a `darasa`) |
+| `Kosa La Leta` (Import Error) | `leta` couldn't find the file, or the requested class/method doesn't exist in it |
+
+## Current limitations
+
+Hamri is a young, evolving language. A few things it doesn't support
+yet:
+
+| Limitation | Details |
+|---|---|
+| Decimal literals | You can't write `3.5` directly in source — decimals currently only appear as a division result. |
+| Negative number literals | You can't write `-5` directly (it's read as subtraction) — store it in a variable via `0 punguza 5` instead. |
+| Parenthesized grouping | You can't use `(...)` to control order of operations inside an expression — break it into steps with intermediate variables instead. |
+| List literals with compound elements | Each item in `[...]` must be a single literal, variable, nested list, or a single function/constructor/property/index call, not its own multi-operator expression (`[1 + 2, 3]` won't work). |
+| Chained indexing | You can't reach into a nested list in one step (`matrix[0][1]`) — assign the inner list to a variable first (`row = matrix[0]`), then index that (`row[1]`). |
+| Removing by value | `ondoa` removes an item by its position, not by matching a value — there's no "remove this value wherever it appears" yet. |
+| No inheritance or static/shared class variables | A `darasa` can't extend another class, and there's no way to share a variable across every instance of a class — only per-instance properties set via `nafsi`. |
+| No bare property declarations in a class body | A `darasa` block may only contain `eleza` method definitions — properties only come into existence once a method (typically the `jenga` constructor) assigns them with `nafsi.property = value`. |
+| No renaming or scoping on `leta` | An imported class/method always keeps its original name, and becomes available everywhere in the file once imported. |
+| `jaza` always reads from the terminal | Even when running a script through the desktop Notepad IDE, `jaza` prompts on the terminal `Notepad.py` was launched from, not in the GUI window itself. |
+| Notepad.py syntax highlighting | The desktop IDE's live syntax highlighting (`__generateTags`) is a pre-existing rough edge that doesn't currently color tokens correctly; script execution (Run/Execute) is unaffected. |
+
+## Full example
+
+Putting it all together — a small program that greets the user,
+classifies their age, counts down, and returns a value from a function:
+
+```
+eleza greet(name)
+    chapa "Habari, " + name
+kwisha
+
+eleza square(x)
+    rudisha x mara x
+kwisha
+
+kwanza
+    jaza "Enter your name: ", jina
+    jaza "Enter your age: ", umri
+
+    greet(jina)
+
+    kama umri > 17
+        chapa "Wewe ni mtu mzima (you are an adult)"
+    sivyo
+        chapa "Wewe ni kijana (you are a minor)"
+    kwisha
+
+    # count down from 3
+    hesabu = 3
+    wakati hesabu > 0
+        chapa hesabu
+        hesabu = hesabu - 1
+    kwisha
+
+    # then count back up
+    huku n kutoka 1 hadi 4
+        chapa n
+    kwisha
+
+    chapa square(4)
+kwisha
+```
+
+The code is properly commented and annotated. Happy coding!
+
+## Follow us on our socials
+
+Instagram — https://www.instagram.com/hamri.lang
+
+Facebook — https://www.facebook.com/hamri.lang
+
+LinkedIn — https://www.linkedin.com/company/hamri-foundation
+
+Email — hello@hamri.org

--- a/StatementParser.py
+++ b/StatementParser.py
@@ -8,17 +8,21 @@ from SymbolTable import symbolTable
 
 from Logger import Log
 
-from LexicalParser import TokenObj
+from LexicalParser import LexicalParser, TokenObj
 
-import tkinter as tk
-
-from Console import console
-
-from pprint import pprint as print_
-
+# tkinter isn't guaranteed to be installed in every environment this
+# interpreter runs in (e.g. a headless server has no display), but the
+# desktop Notepad IDE still passes a real Tk Text widget as the
+# 'console' object. Fall back to a tiny stand-in so `tk.END` still
+# resolves everywhere, even without tkinter installed.
+try:
+    import tkinter as tk
+except ImportError:
+    class _FakeTk:
+        END = 'end'
+    tk = _FakeTk()
 
 global variables
-
 variables= {"variables" :{
 "global":{},
 "local":{}
@@ -31,246 +35,821 @@ variables= {"variables" :{
 }
 }
 
+global console
+console = None
+
+
 
 context = {"var-scope": "global","function-scope":"kwanza","class-scope":"kwanza"}
 definition_flag = False
 call_flag = False
 
+def breadcrumb(json_dict_or_list, value):
+    if json_dict_or_list == value:
+        return [json_dict_or_list]
+    elif isinstance(json_dict_or_list, dict):
+        for k, v in json_dict_or_list.items():
+            p = breadcrumb(v, value)
+            if p:
+                return [k] + p
+    elif isinstance(json_dict_or_list, list):
+        lst = json_dict_or_list
+        for i in range(len(lst)):
+            p = breadcrumb(lst[i], value)
+            if p:
+                return [str(i)] + p
             
 class StatementParser:
-    # Initialize the compound statement dictionary with empty lists for 'kwanza' and 'functions'
-    compound_statement = {"kwanza": [], "functions": {}}
-    
-    # Set the context to the 'kwanza' list in the compound_statement
+    compound_statement = {"kwanza":[],"functions":{}}
     context = compound_statement['kwanza']
-    
-    # Set the prev_context to the 'kwanza' list in the compound_statement
     prev_context = compound_statement['kwanza']
-    
-    # Declare the global variables call_flag and definition_flag
     global call_flag
     global definition_flag
 
-    # Set the function_flag to 'kwanza'
     function_flag = 'kwanza'
     
-    def __init__(self, tokens):
-        # Initialize the StatementParser instance with the given tokens
+    def __init__(self,tokens):
         self.tokens = tokens
-        
-        # Set the token_position to 0 (start position)
         self.token_position = 0
+        self.if_counter = 0
+        self.loop_counter = 0
+        # Tracks the currently-open (not yet closed by 'kwisha')
+        # IfStatement objects, so 'sivyo' knows which one to attach
+        # its else-branch to.
+        self.if_stack = []
+
+        # Name of the darasa (class) currently being defined, if any -
+        # lets 'eleza' know to register the method under a class-
+        # qualified name ('darasa-ClassName-methodName') instead of a
+        # bare one. A stack rather than a single value in case classes
+        # ever end up defined in a nested position.
+        self.class_stack = []
+
+        # Tracks, for every currently-open block, whether entering it
+        # pushed a symbolTable scope ('scoped' - kwanza/kama/eleza/wakati/
+        # huku, all of which need the matching 'kwisha' to pop that scope
+        # via EndBlockStatement) or not ('darasa' - a class body doesn't
+        # push a scope at all, it only tracks class_stack, so its
+        # matching 'kwisha' must NOT also trigger a pop_scope()).
+        self.block_stack = []
 
         
 
         
 
-    def parseStatement(self, parse_token):
+    def parseStatement(self,parse_token):
         global call_flag
         
-        # Get the next and previous tokens for context analysis
-        next_ = self.next_token() if self.token_position < len(self.tokens) - 1 else None
+        
+        next_ = self.next_token() if self.token_position < len(self.tokens)-1 else None
         prev_ = self.prev_token() if self.token_position > 0 else None
-        Log(parse_token.value, "parsing token")
+        Log(parse_token.value,"parsing token")
         
-        statement = None #value to be returned. Initiated to None
+        statement = None
         
-        # Check for the "chapa" keyword indicating a print statement
-        if parse_token.value == 'chapa' and next_ is not None:
+        if parse_token.value == 'chapa' and next_ != None:
             Log('case for print')
-            # Parse the expression inside the parentheses and create a PrintStatement object
-            statement = PrintStatement(ExpressionParser(self.fetch_express()).parse())
-        
-        # Check for the "=" symbol indicating an assignment statement
-        elif parse_token.value == '=' and next_ is not None and prev_ is not None:
+            statement = PrintStatement(self.parse_expression_value())
+        elif parse_token.value == 'aina' and next_ != None:
+            Log('case for type introspection')
+            statement = TypeStatement(self.parse_expression_value())
+        elif parse_token.value == '=' and next_ != None and prev_ != None:
             Log('case for assignment')
-            # Create a Var object with the variable name, the evaluated expression, and the variable scope,
-            # then create an AssignmentStatement object with the Var object
-            obj = Var((prev_.value, ExpressionParser(self.fetch_express()).parse(), symbolTable.get_scope('var-scope')))
+
+            value = self.parse_expression_value()
+            # qualify=True - this is an ordinary user assignment, so if
+            # it's local it should be isolated to whichever call is
+            # actually executing at runtime (see Var/SymbolTable.write_local),
+            # not shared flatly across every function in the program.
+            obj = Var((prev_.value,value,symbolTable.get_scope('var-scope'),True))
             statement = AssignmentStatement(obj)
-        
-        # Check for the "kwisha" keyword indicating the end of a block
+        elif parse_token.value == 'eleza':
+            Log('case for function definition')
+            symbolTable.def_flag = True
+            raw_name = next_.value
+            # Inside a darasa block, a method's name gets class-qualified
+            # ('darasa-Mtu-jenga' instead of just 'jenga') so it can't
+            # collide with a top-level function or a method of the same
+            # name on a different class - everything else (parameter
+            # placeholders, calling, scoping) then works completely
+            # unchanged, since it's still just a normal function under
+            # the hood.
+            function_name = 'darasa-{}-{}'.format(self.class_stack[-1],raw_name) if self.class_stack else raw_name
+            self.token_position = next_.position() + 1
+
+            statement = FunctionDefinitionStatement((function_name,self.fetch_express()))
+
+
+        elif parse_token.value == 'kama':
+            Log('case for if block')
+            self.if_counter = self.if_counter + 1
+            block_name = 'kama-{}'.format(self.if_counter)
+            condition = ExpressionParser(self.fetch_express()).parse()
+
+            statement = IfStatement((block_name,condition))
+            self.if_stack.append(statement)
+
+        elif parse_token.value == 'sivyo':
+            Log('case for otherwise')
+            # Attaches an else-branch to the innermost still-open kama;
+            # does NOT push/pop the scope stack - it swaps the current
+            # block in place, since 'kwisha' still only fires once for
+            # the whole kama...sivyo...kwisha construct.
+            if self.if_stack:
+                current_if = self.if_stack[-1]
+                self.if_counter = self.if_counter + 1
+                else_name = 'sivyo-{}'.format(self.if_counter)
+                current_if.set_else(else_name)
+                symbolTable.set_function(else_name)
+                symbolTable.context['function-scope'] = else_name
+
+        elif parse_token.value == 'wakati':
+            Log('case for while loop')
+            self.loop_counter = self.loop_counter + 1
+            loop_name = 'wakati-{}'.format(self.loop_counter)
+            condition = ExpressionParser(self.fetch_express()).parse()
+
+            statement = WhileStatement((loop_name,condition))
+
+        elif parse_token.value == 'huku':
+            Log('case for for-loop')
+            # Two forms: 'huku <var> kutoka <start> hadi <end>' (counted
+            # range) or 'huku <var> kwenye <list>' (for-each over a
+            # list's items). fetch_express() already stops on its own
+            # once it hits a non-operator token, so it naturally stops
+            # right at 'kutoka'/'hadi'/'kwenye' without any extra
+            # bookkeeping - we just need to manually step over those
+            # marker keywords in between.
+            self.loop_counter = self.loop_counter + 1
+            loop_name = 'huku-{}'.format(self.loop_counter)
+
+            var_name = self.next_token().value
+            self.token_position = self.token_position + 1  # land on <var>
+
+            marker = self.next_token()
+
+            if marker is not None and marker.value == 'kwenye':
+                self.token_position = self.token_position + 1  # land on 'kwenye'
+                list_name = self.next_token().value
+                self.token_position = self.token_position + 1  # land on <list-name>
+
+                statement = ForEachStatement((loop_name,var_name,list_name))
+
+            else:
+                self.token_position = self.token_position + 1  # land on 'kutoka'
+                start_expr = self.parse_expression_value()
+
+                self.token_position = self.token_position + 1  # land on 'hadi'
+                end_expr = self.parse_expression_value()
+
+                statement = ForStatement((loop_name,var_name,start_expr,end_expr))
+
+        elif parse_token.value == 'rudisha':
+            Log('case for return statement')
+            # 'rudisha' can stand alone (just exits the function early,
+            # e.g. as a guard clause) or carry a value: 'rudisha <expr>'.
+            # A bare rudisha is always immediately followed by 'kwisha'
+            # (every block ends with exactly one) - keyword-typed tokens
+            # never start a real expression, so that's how "no value" is
+            # told apart from an actual expression starting here.
+            if next_ is None or next_.token_type == 'keyword':
+                expr = None
+            else:
+                expr = self.parse_expression_value()
+
+            statement = ReturnStatement(expr)
+
+        elif parse_token.value == 'weka':
+            Log('case for list append')
+            # 'weka <value-expr> kwenye <list-name>' - "put <value> into
+            # <list>". fetch_express() naturally stops at 'kwenye' (a
+            # keyword, not an operator), same trick as kutoka/hadi.
+            value_expr = self.parse_expression_value()
+
+            self.token_position = self.token_position + 1  # land on 'kwenye'
+            list_name = self.next_token().value
+            self.token_position = self.token_position + 1  # land on <list-name>
+
+            statement = AppendStatement(list_name,value_expr)
+
+        elif parse_token.value == 'ondoa':
+            Log('case for list remove')
+            # 'ondoa <index-expr> kutoka <list-name>' - "remove <index>
+            # from <list>". Removes by position (like Python's `del
+            # lst[i]`), not by matching a value - reuses the existing
+            # 'kutoka' ("from") keyword as the marker, same trick as
+            # weka's 'kwenye'.
+            index_expr = self.parse_expression_value()
+
+            self.token_position = self.token_position + 1  # land on 'kutoka'
+            list_name = self.next_token().value
+            self.token_position = self.token_position + 1  # land on <list-name>
+
+            statement = RemoveStatement(list_name,index_expr)
+
+        elif parse_token.value == 'darasa':
+            Log('case for class definition')
+            # 'darasa ClassName ... kwisha' - a class body only ever
+            # contains 'eleza' method definitions (no loose statements),
+            # so unlike kwanza/kama/wakati/huku there's no need to push a
+            # symbolTable scope here at all - we just need 'eleza' below
+            # to know it should class-qualify method names until the
+            # matching 'kwisha'. That's tracked via class_stack; the
+            # matching 'kwisha' is told apart from a "real" scoped
+            # block's kwisha via block_stack (see below).
+            class_name = next_.value
+            self.token_position = self.token_position + 1  # land on <class-name>
+            symbolTable.set_class(class_name)
+            self.class_stack.append(class_name)
+            self.block_stack.append('darasa')
+
+        elif parse_token.value == 'leta':
+            Log('case for import')
+            # Two forms, both starting with a comma-separated name list:
+            #   leta Mtu, Mnyama kutoka "faili"          - whole class(es)
+            #   leta salamu, tembea kutoka Mtu kutoka "faili"  - specific
+            #     method(s) of one class, imported standalone
+            # Told apart by what follows the first 'kutoka': a string
+            # literal means "that's the file" (whole-class form); a bare
+            # name means "that's a class name" (selective-method form),
+            # with a second 'kutoka' + string still to come. This is all
+            # resolved immediately, at parse time - like 'darasa'/'eleza',
+            # 'leta' has no runtime behaviour of its own, it just makes
+            # names available for the rest of the file to use.
+            names = [next_.value]
+            self.token_position = self.token_position + 1  # land on first name
+
+            while self.next_token() is not None and self.next_token().value == ',':
+                self.token_position = self.token_position + 1  # land on ','
+                self.token_position = self.token_position + 1  # land on next name
+                names.append(self.tokens[self.token_position].value)
+
+            self.token_position = self.token_position + 1  # land on 'kutoka'
+            after_kutoka = self.next_token()
+
+            if after_kutoka is not None and after_kutoka.token_type == 'string':
+                self.token_position = self.token_position + 1  # land on the filename string
+                filename = self.tokens[self.token_position].value
+                self.import_classes(names,filename)
+            else:
+                class_name = after_kutoka.value if after_kutoka is not None else None
+                self.token_position = self.token_position + 1  # land on <class-name>
+                self.token_position = self.token_position + 1  # land on 'kutoka'
+                self.token_position = self.token_position + 1  # land on the filename string
+                filename = self.tokens[self.token_position].value
+                self.import_methods(names,class_name,filename)
+
+        elif parse_token.value == 'kwanza':
+            Log('case for main block')
+            # kwanza ("first") is the program's required entry point -
+            # only code inside kwanza...kwisha actually runs. Statements
+            # outside it (e.g. helper function definitions) are still
+            # parsed but never auto-executed. No statement object is
+            # needed here; opening the block is just a scope change.
+            symbolTable.push_scope('kwanza')
+            self.block_stack.append('scoped')
+
         elif parse_token.value == 'kwisha':
             Log('case for end block')
-            # Reset the definition flag and create an EndBlockStatement object with the current context
             symbolTable.reset_flags()
-            statement = EndBlockStatement(symbolTable.context)
-        
-        # Check for the "jaza" keyword indicating an input statement
+            current_scope = symbolTable.get_scope('function-scope')
+            if self.if_stack and current_scope in (self.if_stack[-1].true_name,self.if_stack[-1].else_name):
+                # This kwisha closes the kama (and its sivyo, if any)
+                # that's currently on top of the stack.
+                self.if_stack.pop()
+
+            # darasa doesn't push a scope (see above), so its matching
+            # kwisha must skip EndBlockStatement/pop_scope entirely -
+            # otherwise it would incorrectly pop whatever scope was
+            # already active *before* the class definition started.
+            block_kind = self.block_stack.pop() if self.block_stack else 'scoped'
+
+            if block_kind == 'darasa':
+                if self.class_stack:
+                    self.class_stack.pop()
+            else:
+                statement = EndBlockStatement(symbolTable.context)
+            
         elif parse_token.value == 'jaza':
             Log('case for user input')
-            self.token_position = self.token_position + 1
-            # Create an InputStatement object with the input prompt and the variable to store the input value
+            #Log(type(self.fetch_express()))
+
+            # Note: fetch_express() already reads relative to "current
+            # position + 1", same as the 'chapa' case above - advancing
+            # token_position first (as this used to) skips the prompt
+            # string entirely and misreads the storage variable.
             statement = InputStatement(self.fetch_express())
             
-        #check for the 'aina' keyword indicating return of object type
-        elif parse_token.value == 'aina':
-            Log('case for return object type')
-            self.token_position = self.token_position + 1
-            # Create an InputStatement object with the input prompt and the variable to store the input value
-            statement = ReturnObjectTypeStatement(ExpressionParser(self.fetch_express()).parse())        
-        
-        # Check for a function call by identifying a variable followed by '('
-        elif parse_token.token_type == 'function':
-            
-            if prev_.value == 'eleza':
-                
-                Log('case for function definition')
-                # Set the function definition flag and extract the function name and parameters
-                symbolTable.def_flag = True
-                function_name = parse_token.value        
-                # Create a FunctionDefinitionStatement object with the function name and parameters
-                expression = self.fetch_express()
-                statement = FunctionDefinitionStatement((function_name, expression))
-                
+        elif parse_token.token_type == 'variable' and next_.value == '(':
+            Log('case for function call')
+            call_flag = True
+            function_name = parse_token.value
+
+            self.token_position = self.token_position + 1 #advance by one to fly over the first divider
+            #Log(self.fetch_express())
+
+            statement = FunctionCallStatement((function_name,self.fetch_express()))
+
+        elif parse_token.token_type == 'variable' and next_.value == '[':
+            Log('case for list indexing')
+            # `orodha[i]` - either read-as-part-of-a-larger-statement
+            # (handled by try_parse_index(), used from '=' and 'chapa'
+            # above, so this branch only ever sees it as the *start* of
+            # its own statement) or a full index-assignment,
+            # `orodha[i] = <value>`.
+            list_name = parse_token.value
+            self.token_position = self.token_position + 1  # land on '['
+            index_expr = ExpressionParser(self.fetch_express()).parse()  # stops at ']'
+
+            after_bracket = self.tokens[self.token_position + 2] if self.token_position + 2 < len(self.tokens) else None
+
+            if after_bracket is not None and after_bracket.value == '=':
+                self.token_position = self.token_position + 2  # skip ']', land on '='
+                value_expr = self.parse_expression_value()
+                statement = IndexAssignmentStatement(list_name,index_expr,value_expr)
             else:
-                Log('case for function call')
-                # Set the call flag and extract the function name
-                call_flag = True
-                function_name = parse_token.value
-                
-                # Create a FunctionCallStatement object with the function name and the parsed expressions as parameters
-                
-                statement = FunctionCallStatement((function_name, self.fetch_express()))
-                
-        elif parse_token.value == 'rudisha':
-            Log('case for function return statement')
-            statement = FunctionReturnStatement(ExpressionParser(self.fetch_express()).parse())
-            
-        
+                # A bare `orodha[i]` with nothing capturing it has no
+                # observable effect - there's nothing to execute. The
+                # closing ']' is skipped harmlessly as a phantom token,
+                # same as the ')' left over after any function call.
+                statement = None
+
+        elif parse_token.token_type == 'variable' and next_.value == '.':
+            Log('case for property/method access')
+            # `obj.member` - either a property write (`obj.jina = value`),
+            # a method call used as its own statement (`obj.sema()`), or
+            # (like a bare `orodha[i]`) a no-op read with nothing to
+            # capture it. Reading a property/calling a method as *part*
+            # of a larger expression is handled separately by
+            # try_parse_property_access(), used from '=' and 'chapa'.
+            object_name = parse_token.value
+            self.token_position = self.token_position + 1  # land on '.'
+            member_name = self.next_token().value
+            self.token_position = self.token_position + 1  # land on <member-name>
+
+            after_member = self.next_token()
+
+            if after_member is not None and after_member.value == '(':
+                self.token_position = self.token_position + 1  # land on '('
+                args = self.fetch_express()
+                statement = MethodCallStatement(object_name,member_name,args)
+            elif after_member is not None and after_member.value == '=':
+                self.token_position = self.token_position + 1  # land on '='
+                value_expr = self.parse_expression_value()
+                statement = PropertyAssignmentStatement(object_name,member_name,value_expr)
+            else:
+                statement = None
+
         else:
             Log('default case')
-        
+            
+            
+            
+
+        #statement = switcher[parse_token.token_type][parse_token.value] if parse_token.token_type in switcher.keys() else None
+
         return statement
 
+    def _parse_module(self,filename):
+        # Fetches and parses an external file's *definitions* (darasa/
+        # eleza) into the shared symbolTable, for 'leta' to import from -
+        # via a completely independent StatementParser instance (its own
+        # token_position/if_stack/class_stack/block_stack) that just
+        # happens to register everything into the same symbolTable
+        # singleton, exactly as if it had been typed directly into this
+        # file. Returns True if the file was found and parsed, False if
+        # symbolTable.load_module_source() couldn't find/read it.
+        source = symbolTable.load_module_source(filename)
+        if source is None:
+            return False
 
-    
-        
-    def fetch_express(self):
-        next_ = self.next_token()  # Get the next token
-        
-        Log('Fetching expression ')
-        
-        
-        if next_.token_type == 'divider':
-            return_val = []  # If the next token is a divider, return an empty list to represent an empty expression i.e func()
-            
-        else:
-            # Evaluate the first token and add it to the return value list
-            return_val = [Object(self.next_token()).cast()]
-            Log(return_val[0], 'First Token')
-            
-            self.token_position = self.token_position + 1  # Advance the execution loop
-            
-            # Process additional tokens if they are operators followed by terms
-            while self.next_token().token_type == 'operator':
-                return_val.append(Object(self.next_token()).cast()) if self.next_token().value != ',' else None  # Add the operator to the return value
-                
-                self.token_position = self.token_position + 1  # Advance the execution loop
-                
-                return_val.append(Object(self.next_token()).cast())  # Add the term to the return value
-                
-                self.token_position = self.token_position + 1
-        
-        Log(return_val, 'Evaluated expression')
-        
+        kwanza_before = len(symbolTable.table['functions']['kwanza'])
+
+        tokens = LexicalParser(source,from_text=True).parse()
+        sub_parser = StatementParser(tokens.token_list)
+        sub_parser.parse(symbolTable.console)
+
+        # A library file might (e.g. for its own standalone testing) have
+        # its own 'kwanza' block - only its definitions are wanted here,
+        # not its main block's statements running as though they were
+        # part of *this* program's kwanza.
+        del symbolTable.table['functions']['kwanza'][kwanza_before:]
+
+        return True
+
+    def import_classes(self,names,filename):
+        # 'leta A, B kutoka "faili"' - pulls in one or more whole classes.
+        if not self._parse_module(filename):
+            Error.throwException('leta',filename)
+            return
+        for name in names:
+            if name not in symbolTable.table['classes']:
+                Error.throwException('leta','{} ({})'.format(name,filename))
+
+    def import_methods(self,names,class_name,filename):
+        # 'leta a, b kutoka ClassName kutoka "faili"' - pulls in one or
+        # more specific methods of a class, callable standalone (see
+        # SymbolTable.alias_function).
+        if not self._parse_module(filename):
+            Error.throwException('leta',filename)
+            return
+        for name in names:
+            qualified_name = 'darasa-{}-{}'.format(class_name,name)
+            if not symbolTable.alias_function(name,qualified_name):
+                Error.throwException('leta','{}.{} ({})'.format(class_name,name,filename))
+
+    def try_parse_special_value(self):
+        # Tries each of the "not a plain fetch_express() expression"
+        # shapes in turn - a list literal, a length lookup, a property
+        # read/method call, an indexed read, or a function call - and
+        # returns the first one that matches (or None if none do, letting
+        # the caller fall back to a plain fetch_express()). Every one of
+        # these leaves self.token_position sitting exactly ON the last
+        # token it consumed (the closing ']'/')' or the bare name/value
+        # itself), so parse_expression_value() below can seamlessly keep
+        # reading a trailing operator + operand after it, the same way
+        # fetch_express() does for a plain value.
+        return (self.try_parse_list_literal()
+                or self.try_parse_length()
+                or self.try_parse_property_access()
+                or self.try_parse_index()
+                or self.try_parse_call())
+
+    def parse_expression_value(self):
+        # Shared by every place that used to do
+        # "try_parse_special_value(), falling back to a plain
+        # fetch_express()" - now also keeps reading past the special
+        # value if it's followed by an operator, e.g.
+        # `jina = nafsi.jina + " Mkenya"` or `chapa square(2) + 1`,
+        # instead of the special value silently swallowing the rest of
+        # the expression.
+        special = self.try_parse_special_value()
+        if special is not None:
+            return ExpressionParser(self.continue_express(special)).parse()
+        return ExpressionParser(self.fetch_express()).parse()
+
+    def continue_express(self,first):
+        # Same operator-chaining loop as fetch_express()'s own while-loop,
+        # but starting from an already-parsed first value (e.g. a
+        # PropertyExpression or CallExpression) instead of casting the
+        # current token - lets a special value returned by
+        # try_parse_special_value() combine with a trailing operator,
+        # e.g. continuing to read "+ ' Mkenya'" after `nafsi.jina`.
+        # Uses read_operand() (not a plain token cast) for every later term
+        # too, same as fetch_express()'s own loop - otherwise a *second*
+        # special value further along the same chain (e.g. the nafsi.sauti
+        # in `nafsi.jina + " anasema " + nafsi.sauti`) would silently fall
+        # back to being cast as a bare variable reference instead of being
+        # recognized as its own property read.
+        return_val = [first]
+        while self.next_token() is not None and self.next_token().token_type == 'operator':
+            operator_token = self.next_token()
+            if operator_token.value != ',':
+                return_val.append(operator_token)
+            self.token_position = self.token_position + 1
+            return_val.append(self.read_operand())
         return return_val
 
+    def try_parse_property_access(self):
+        # Detects `name.member` (property read, e.g. `x = mtu1.jina`) or
+        # `name.member(args)` (method call, e.g. `x = mtu1.sema_habari()`)
+        # starting right after the current token.
+        first = self.next_token()
+        second = self.tokens[self.token_position + 2] if self.token_position + 2 < len(self.tokens) else None
+
+        if first is not None and first.token_type == 'variable' and second is not None and second.value == '.':
+            object_name = first.value
+            third = self.tokens[self.token_position + 3] if self.token_position + 3 < len(self.tokens) else None
+            if third is None:
+                return None
+            member_name = third.value
+            fourth = self.tokens[self.token_position + 4] if self.token_position + 4 < len(self.tokens) else None
+
+            if fourth is not None and fourth.value == '(':
+                self.token_position = self.token_position + 4  # land on '('
+                args = self.fetch_express()
+                self.token_position = self.token_position + 1  # land on ')' (fetch_express stops one token early)
+                return MethodCallExpression(object_name,member_name,args)
+            else:
+                self.token_position = self.token_position + 3  # land on <member-name>
+                return PropertyExpression(object_name,member_name)
+
+        return None
+
+    def try_parse_list_literal(self):
+        # Detects a `[...]` list literal starting right after the current
+        # token - e.g. `[1, 2, 3]` or `[1, [2, 3], 4]`. Unlike
+        # fetch_express()'s comma handling (used for flat argument lists),
+        # this recurses into itself for any element that's itself a `[`,
+        # so lists can nest to any depth. Fully consumes through its own
+        # closing ']' (leaves self.token_position sitting ON it) rather
+        # than relying on a later "phantom skip" - important so that,
+        # when called recursively for a nested element, the *outer* list
+        # can correctly see what comes right after the inner ']' (a ','
+        # or the outer ']').
+        first = self.next_token()
+
+        if first is None or first.value != '[':
+            return None
+
+        self.token_position = self.token_position + 1  # land on '['
+        elements = []
+
+        if self.next_token() is not None and self.next_token().value == ']':
+            self.token_position = self.token_position + 1  # land on ']' (empty list)
+            return ListLiteral(elements)
+
+        while True:
+            nested = self.try_parse_list_literal()
+            if nested is not None:
+                elements.append(nested)
+            else:
+                # An element can also be a `name(args)` call - most
+                # importantly, a class constructor call like `Mtu("Amara")`,
+                # so a list of instances (`[Mtu("Amara"), Mtu("Juma")]`) can
+                # be built directly. CallExpression already transparently
+                # handles "name is actually a darasa" via
+                # FunctionCallStatement.execute(), so no extra branching is
+                # needed here for that case.
+                elem_token = self.tokens[self.token_position + 1] if self.token_position + 1 < len(self.tokens) else None
+                after_elem = self.tokens[self.token_position + 2] if self.token_position + 2 < len(self.tokens) else None
+                if elem_token is not None and elem_token.token_type == 'variable' and after_elem is not None and after_elem.value == '(':
+                    function_name = elem_token.value
+                    self.token_position = self.token_position + 2  # land on '('
+                    args = self.fetch_express()
+                    self.token_position = self.token_position + 1  # land on ')' (fetch_express stops one token early)
+                    elements.append(CallExpression(function_name,args))
+                else:
+                    self.token_position = self.token_position + 1  # move onto the element token
+                    elements.append(Object(self.tokens[self.token_position]).cast())
+
+            after = self.next_token()
+            if after is not None and after.value == ',':
+                self.token_position = self.token_position + 1  # land on ','
+                continue
+            elif after is not None and after.value == ']':
+                self.token_position = self.token_position + 1  # land on ']'
+                break
+            else:
+                # Malformed (missing closing bracket) - bail out rather
+                # than looping forever or crashing.
+                break
+
+        return ListLiteral(elements)
+
+    def try_parse_length(self):
+        # Detects `idadi <list-name>` (length of a list) starting right
+        # after the current token.
+        first = self.next_token()
+
+        if first is not None and first.value == 'idadi':
+            self.token_position = self.token_position + 1  # land on 'idadi'
+            list_name = self.next_token().value
+            self.token_position = self.token_position + 1  # land on <list-name>
+            return LengthExpression(list_name)
+
+        return None
+
+    def try_parse_index(self):
+        # Detects a `name[index-expr]` indexed read starting right after
+        # the current token - e.g. the right-hand side of `x = orodha[0]`
+        # or `chapa orodha[0]`. (The left-hand-side/assignment-target
+        # case, `orodha[0] = value`, is handled separately in
+        # parseStatement, since it needs to become a whole statement
+        # rather than a value.)
+        first = self.next_token()
+        second = self.tokens[self.token_position + 2] if self.token_position + 2 < len(self.tokens) else None
+
+        if first is not None and first.token_type == 'variable' and second is not None and second.value == '[':
+            list_name = first.value
+            self.token_position = self.token_position + 2  # land on '['
+            index_expr = ExpressionParser(self.fetch_express()).parse()
+            self.token_position = self.token_position + 1  # land on ']' (fetch_express stops one token early)
+            return IndexExpression(list_name,index_expr)
+
+        return None
+
+    def try_parse_call(self):
+        # Lets a function's return value be captured as part of a larger
+        # statement - `x = square(5)` or `chapa square(5)` - by detecting
+        # a `name(...)` shape starting right after the current token and,
+        # if found, consuming it and returning a CallExpression. Returns
+        # None *without* consuming anything if the shape doesn't match,
+        # so the caller falls back to the normal fetch_express() path.
+        first = self.next_token()
+        second = self.tokens[self.token_position + 2] if self.token_position + 2 < len(self.tokens) else None
+
+        if first is not None and first.token_type == 'variable' and second is not None and second.value == '(':
+            function_name = first.value
+            self.token_position = self.token_position + 2  # land on '('
+            args = self.fetch_express()
+            self.token_position = self.token_position + 1  # land on ')' (fetch_express stops one token early)
+            return CallExpression(function_name,args)
+
+        return None
+
+    def read_operand(self):
+        # Tries every "special value" shape first - list literal, length,
+        # property/method access, indexed read, function call - so an
+        # operand ANYWHERE in an expression (not just a leading one) can
+        # be one of these, e.g. the `mtu1.jina` in `"Habari, " + mtu1.jina`,
+        # or the `orodha[0]` in `f(orodha[0], 5)`. Falls back to casting
+        # the current token directly (the original, single-token-only
+        # behaviour) if none of them match.
+        special = self.try_parse_special_value()
+        if special is not None:
+            return special
+        operand = Object(self.next_token()).cast()
+        self.token_position = self.token_position + 1
+        return operand
+
+    def fetch_express(self):
+        next_ = self.next_token()
+
+        Log('Fetching expression ')
+
+        if next_ is None:
+            # Statement was the last token in the script (e.g. a lone
+            # 'chapa "hi"' with nothing after it) - nothing more to read.
+            return_val = []
+
+        elif next_.token_type == 'divider':
+            return_val = []
+
+
+        else:
+
+            return_val = [self.read_operand()]
+            Log(return_val[0],'First Token')
+
+            while self.next_token() is not None and self.next_token().token_type == 'operator':
+                operator_token = self.next_token()
+                if operator_token.value != ',':
+                    return_val.append(operator_token) #add our operator
+
+                self.token_position = self.token_position + 1 #advance our execution loop
+
+                return_val.append(self.read_operand()) #add our term
+
+        Log(return_val,'Evaluated expression')
+        return return_val
         
     
     def print_statements(self):
-        #print the symbol table
-        print_(symbolTable.table)
+        print(symbolTable.table)
             
     def next_token(self):
-        #fetch the next token in our loop
-        
-        return self.tokens[self.token_position + 1]
-    
-    def prev_token(self):
-        #fetch the previous token in our loop
-        
-        return self.tokens[self.token_position - 1]    
+        pos = self.token_position + 1
+        return self.tokens[pos] if 0 <= pos < len(self.tokens) else None
 
-    def parse(self):
-    
+    def prev_token(self):
+        pos = self.token_position - 1
+        return self.tokens[pos] if 0 <= pos < len(self.tokens) else None
+
+    def parse(self,arg=None):
+        global console
+
+        console = arg
+        symbolTable.console = arg
+
         Log('=======================')
         Log('Statement Parsing')
-        Log('=======================')
-    
-        # Iterate through the tokens
+        Log('=======================')        
+        
         while self.token_position < len(self.tokens):
-            # Parse the current token and get the corresponding statement
+            
             statement = self.parseStatement(self.tokens[self.token_position])
-    
-            # Log the evaluated statement and current context
-            Log(statement, 'Evaluated statement')
-            Log(symbolTable.get_scope('function-scope'), 'Current context')
-    
-            # Append the statement to the current function scope
+            
+            #print('Function definition flag:',symbolTable.def_flag)
+ 
+            Log(statement,'Evaluated statement')
+            Log(symbolTable.get_scope('function-scope'),'Current context')
+            
             symbolTable.table['functions'][symbolTable.get_scope('function-scope')].append(statement) if statement else None
-    
-            # Log the current symbol table state
-            Log(symbolTable.table, 'Current symbol table state')
-    
-            # Handle function definitions
+            
+            Log(symbolTable.table,'Current symbol table state')
+            
             if type(statement).__name__ == 'FunctionDefinitionStatement':
-                # Change to function scope
-                symbolTable.set_scope(('var-scope', 'local'))
-                symbolTable.set_scope(('function-scope', statement.name))
-    
-            self.token_position = self.token_position + 1  # Move to the next token
-    
-        return self
 
+                #change to a fresh local scope for the function body;
+                #'kwisha' will pop back to whatever scope we came from
+
+                symbolTable.push_scope(statement.name,'local')
+                self.block_stack.append('scoped')
+
+            elif type(statement).__name__ == 'IfStatement':
+
+                #route subsequent statements into this if-block until 'kwisha'
+                #(or into its sivyo branch, see the 'sivyo' case
+                #above); variables stay in the enclosing (not a fresh
+                #local) scope
+
+                symbolTable.push_scope(statement.true_name)
+                self.block_stack.append('scoped')
+
+            elif type(statement).__name__ == 'WhileStatement':
+
+                #route subsequent statements into this loop's body until
+                #'kwisha'; variables stay in the enclosing scope, same as kama
+
+                symbolTable.push_scope(statement.name)
+                self.block_stack.append('scoped')
+
+            elif type(statement).__name__ in ('ForStatement','ForEachStatement'):
+
+                #same idea as WhileStatement - body statements are routed
+                #into this loop's own scope until 'kwisha', while the loop
+                #variable and everything else stay in the enclosing scope
+
+                symbolTable.push_scope(statement.name)
+                self.block_stack.append('scoped')
+
+            self.token_position = self.token_position + 1
+
+                
+            
+        return self
         
 
     def execute(self):
-        #clear our console first with some beginning text
-            
+        #clear our console
         
+        global console
+        
+        # Falls back to plain print() whenever no console object was
+        # supplied (e.g. running a script directly via main.py, with no
+        # Tk widget/web console in the picture) - the same fallback
+        # Errors._report() already uses, so a script never runs
+        # completely silently just because .parse() wasn't given a
+        # console.
+        if console is not None:
+            console.insert(1.0,'=====================================\nRunning Hamri script\n=====================================\n')
+        else:
+            print('=====================================\nRunning Hamri script\n=====================================')
         Log('=======================')
         Log('Statement Execution')
         Log('=======================')
-        
-        
-        #start our console
-        console.start_console()
-        
-        
-        
-        #Hamri's main execution loop is this right here
-        
-        for i in symbolTable.table['functions'][symbolTable.get_scope('function-scope')]:
-            
-            #check if the exit code in the symbol table is set to 0 
-             
-            if symbolTable.exit() == 0:
-                Log(symbolTable.get_scope('function-scope'),'Executing from scope')
-                Log(i,'Executing statement')
-                
-                #execute the statement if the exit is 0
-                i.execute()
-                
+
+        # Only the explicit 'kwanza' (main) block actually runs. This is
+        # a fixed name, not "whatever scope parsing ended on" - after a
+        # properly closed kwanza...kwisha, the parser scope will already
+        # have popped back to 'nje' by the time we get here.
+        if not symbolTable.table['functions']['kwanza']:
+            message = 'Hakuna kwanza (no main block found) - wrap the code you want to run in kwanza ... kwisha.\n'
+            if console is not None:
+                console.insert(tk.END,message)
             else:
-                #break the execution loop
+                print(message)
+            Log(message,'Execution')
+
+        for i in symbolTable.table['functions']['kwanza']:
+
+            # A bare 'rudisha' reaching all the way out here (not inside
+            # any function) has no caller left to return to - treat it as
+            # an early, intentional stop of the whole program.
+            if symbolTable.exit() == 0 and not symbolTable.is_returning():
+                Log('kwanza','Executing from scope')
+                Log(i,'Executing statement')
+                i.execute()
+
+            else:
                 break
             
-        #print out execution code statement at the end of the execution loop
+        if symbolTable.exit() == 0:
+            if console is not None:
+                console.insert(tk.END,'\n=====================================\nHamri script execution success with exit code 0\n=====================================')
+            else:
+                print('\n=====================================\nHamri script execution success with exit code 0\n=====================================')
+
+            Log('\n=====================================\nHamri script execution success with exit code 0\n=====================================','Executing Success')
+        else:
+            if console is not None:
+                console.insert(tk.END,'\n=====================================\nHamri script execution fail with exit code 1\n=====================================')
+            else:
+                print('\n=====================================\nHamri script execution fail with exit code 1\n=====================================')
         
-        Log('=======================')
-        Log('Statement Execution Completed')
-        Log('=======================')
         
-        #stop our console and clear the symbolTable
-        console.close_console()
-        symbolTable.reset_table()
-        
+        #try:
+            
+            #for i in symbolTable.table['functions'][symbolTable.get_scope('function-scope')]:
+                
+                #Log(symbolTable.get_scope('function-scope'),'Executing from scope')
+                
+                #Log(i,'Executing statement')
+                #i.execute()
+                
+                
+            #print('\n=====================================\nHamri script execution success with exit code 0\n=====================================')
+                    
+        #except Exception as e:
+            #Log(e,'Exception')
+            #print('\n=====================================\nHamri script execution failed with exit code 1\n=====================================')
 
 
 
 
-# Class to represent a statement in the Hamri programming language
+
+
 class Statement:
     def __init__(self):
         None
@@ -278,208 +857,670 @@ class Statement:
     def execute(self):
         None
 
-# Class to represent a function call statement
+
+    
 class FunctionCallStatement(Statement):
-    def __init__(self, arg):
-        # Name of the function being called
+    def __init__(self,arg):
         self.name = arg[0]
-        # Parameters passed to the function
         self.params = arg[1]
+        # Set when this call is actually a method call bound to a
+        # specific object (see MethodCallExpression) or the constructor
+        # step of instantiating a new object (see the 'darasa' branch
+        # below) - the instance gets bound to a local 'nafsi' variable
+        # before the body runs, exactly like any other parameter.
+        self.instance = arg[2] if len(arg) > 2 else None
+        # What 'rudisha' inside this function last produced, once
+        # execute() has run - None if the function never hit a rudisha
+        # (or was never called with a return value). For a class
+        # instantiation call, this instead ends up holding the newly
+        # created instance itself (see below).
+        self.return_value = None
+
+
 
     def execute(self):
-        # Assign parameter values to function arguments
-        #set the scope to the executing function's name
-        symbolTable.set_scope(('function-scope',self.name))
-        
-        Log(symbolTable.get_function_arguments(self.params), 'Function Parameters')
-        
-        assignments = list(zip(symbolTable.get_function_arguments(self.name), self.params))
-        
-        Log(list(assignments), 'Function Arguments')
 
-        # Evaluate and assign parameter values to local variables
+        if self.name in symbolTable.table['classes']:
+            # `Mtu(args)` where 'Mtu' is a class, not a function -
+            # construct a new instance instead of calling a function.
+            # Reuses this same class for running the constructor (if the
+            # class defines one) purely so argument-binding/nafsi/return-
+            # flag handling don't need to be duplicated.
+            instance = Instance(self.name)
+            constructor_name = 'darasa-{}-jenga'.format(self.name)
+            if constructor_name in symbolTable.table['functions']:
+                constructor_call = FunctionCallStatement((constructor_name,self.params,instance))
+                constructor_call.execute()
+                # A constructor's own 'rudisha' (if it used one) is
+                # intentionally discarded - instantiating a class always
+                # yields the instance itself, not whatever the
+                # constructor happened to return.
+            self.return_value = instance
+            return
+
+        if self.name not in symbolTable.table["functions"]:
+            # Calling something that was never defined with 'eleza' used
+            # to raise a raw Python KeyError straight through to the user.
+            Error.throwException('kazi',self.name)
+            self.return_value = None
+            return
+
+        #assign our function definition arguments to the calling argument values before running function
+        assignments = list(zip(symbolTable.get_function_arguments(self.name),self.params))
+
+        Log(list(assignments),'Function Arguments')
+
         for i in assignments:
-            #set new local variable with the intended value
-            Var((i[0], i[1], 'local')).evaluate()
 
-        # Set the function call flag in the symbol table
-        symbolTable.en_flag('call', self.name)
+            Var((i[0],i[1],'local')).evaluate()
 
-        # Execute statements inside the function
+        if self.instance is not None:
+            # Bind 'nafsi' the same way a normal parameter is bound - a
+            # plain local variable, just namespaced under this call's
+            # qualified name so it doesn't leak into unrelated calls.
+            Var(('function-{}-nafsi'.format(self.name),self.instance,'local')).evaluate()
+
+        #enable our call flag
+
+        symbolTable.en_flag('call',self.name)
+
+        # Defensive: make sure we're not somehow starting this call already
+        # "returning" from something unrelated.
+        symbolTable.clear_return()
+
         for i in symbolTable.table["functions"][self.name]:
-            Log(self.name, 'Executing from function scope')
-            Log(i, 'Executing statement')
+
+            if symbolTable.exit() != 0 or symbolTable.is_returning():
+                break
+
+            Log(self.name,'Executing from function scope')
+
+            Log(i,'Executing statement')
+
             i.execute()
 
-        # Reset flags after executing the function
-        symbolTable.reset_flags()
+        # This is the function-call boundary: absorb the return flag here
+        # so it stops propagating - the caller's own control flow (the
+        # loop/block it called us from) must not also think *it* should
+        # return just because the function we called did.
+        self.return_value = symbolTable.return_value
+        symbolTable.clear_return()
 
-# Class to represent a function definition statement
-class FunctionDefinitionStatement(Statement):
-    def __init__(self, arg):
-        # Name of the function being defined
-        self.name = arg[0]
-        # Parameters of the function
-        self.params = arg[1]
-        # Set the current function scope in the symbol table
-        symbolTable.set_function(self.name)
-        Log('created new function {} with params: '.format(self.name), 'Function Definition')
+        # Pop just this call off the call stack (restoring call_flag to
+        # whichever call was running before it, if any) rather than
+        # unconditionally clearing call_flag to False - that used to mean
+        # a nested call (function A calling function B) would, the moment
+        # B returned, make A's *own* remaining local variables look like
+        # they were no longer "inside a call" at all, so they'd leak into
+        # globals instead of staying isolated to A.
+        symbolTable.def_flag = False
+        symbolTable.pop_call()
+
+
+class CallExpression(Object):
+    # Lets a function's return value be used directly - `x = square(5)`
+    # or `chapa square(5)` - instead of only being able to call a
+    # function as its own standalone statement. Runs the call fresh every
+    # time it's evaluated (so it re-reads current argument values each
+    # time, same as any other expression), and yields whatever 'rudisha'
+    # produced inside it - None if it never hit one.
+    def __init__(self,name,args):
+        self.call = FunctionCallStatement((name,args))
+
+    def evaluate(self):
+        self.call.execute()
+        return self.call.return_value
+
+
+def _fetch_list(list_name):
+    # Shared lookup used by every list operation (index read/write,
+    # append, length, for-each): finds the variable, makes sure it's
+    # actually holding a list, and reports a clear error otherwise
+    # instead of a raw Python crash. Returns None (with the relevant
+    # error already thrown) if anything's wrong.
+    stored = symbolTable.fetch_variable(list_name)
+    if not stored:
+        Error.throwException('anwani',list_name)
+        return None
+    value = stored.evaluate()
+    if not isinstance(value,list):
+        Error.throwException('orodha',list_name)
+        return None
+    return value
+
+
+class Instance:
+    # A single object created from a 'darasa' (class). Its properties
+    # live in their own dedicated corner of symbolTable's variable
+    # storage (keyed by scope_key, one per instance) - completely
+    # separate from every other instance's properties, even instances of
+    # the same class, and from ordinary local/global variables.
+    def __init__(self,class_name):
+        self.class_name = class_name
+        self.scope_key = 'instance-{}-{}'.format(class_name,symbolTable.new_instance_id())
+        symbolTable.table['variables'][self.scope_key] = {}
+
+    def __str__(self):
+        return '<{} instance>'.format(self.class_name)
+
+
+def _fetch_instance(name):
+    # Shared lookup used by every property/method operation: finds the
+    # variable, makes sure it's actually holding an object (an Instance),
+    # and reports a clear error otherwise instead of a raw Python crash.
+    stored = symbolTable.fetch_variable(name)
+    if not stored:
+        Error.throwException('anwani',name)
+        return None
+    value = stored.evaluate()
+    if not isinstance(value,Instance):
+        Error.throwException('darasa',name)
+        return None
+    return value
+
+
+class PropertyExpression(Object):
+    # `obj.jina` used as a value - `x = mtu1.jina` or `chapa mtu1.jina`.
+    def __init__(self,object_name,property_name):
+        self.object_name = object_name
+        self.property_name = property_name
+
+    def evaluate(self):
+        instance = _fetch_instance(self.object_name)
+        if instance is None:
+            return None
+        properties = symbolTable.table['variables'][instance.scope_key]
+        if self.property_name not in properties:
+            # Reads the same way an undefined plain variable would -
+            # this property was simply never set on this object.
+            Error.throwException('anwani',self.property_name)
+            return None
+        return properties[self.property_name].evaluate()
+
+
+class PropertyAssignmentStatement(Statement):
+    # `obj.jina = <value>` - sets (or creates) a property directly on an
+    # existing object. Used both for external assignment (`mtu1.jina =
+    # "Amara"`) and, just as importantly, for `nafsi.jina = jina` inside
+    # a method - 'nafsi' is nothing special here, just a local variable
+    # that happens to hold the current instance.
+    def __init__(self,object_name,property_name,value_expr):
+        self.object_name = object_name
+        self.property_name = property_name
+        self.value_expr = value_expr
 
     def execute(self):
-        # Create local variables for function arguments
-        Log('creating new arguments: {}'.format(self.params))
+        instance = _fetch_instance(self.object_name)
+        if instance is None:
+            return
+        value = self.value_expr.evaluate()
+        if symbolTable.exit() != 0:
+            return
+        symbolTable.table['variables'][instance.scope_key][self.property_name] = Literal(value)
+
+
+class MethodCallExpression(Object):
+    # `obj.method(args)` used as a value - `x = mtu1.sema()` or
+    # `chapa mtu1.sema()`. Resolves which class's method to run from the
+    # object's own class (not from however the variable happens to be
+    # named), then reuses FunctionCallStatement so argument binding,
+    # nafsi-binding, and rudisha/return handling all work exactly the
+    # same as a plain function call.
+    def __init__(self,object_name,method_name,args):
+        self.object_name = object_name
+        self.method_name = method_name
+        self.args = args
+
+    def evaluate(self):
+        instance = _fetch_instance(self.object_name)
+        if instance is None:
+            return None
+        qualified_name = 'darasa-{}-{}'.format(instance.class_name,self.method_name)
+        if qualified_name not in symbolTable.table['functions']:
+            Error.throwException('kazi',self.method_name)
+            return None
+        call = FunctionCallStatement((qualified_name,self.args,instance))
+        call.execute()
+        return call.return_value
+
+
+class MethodCallStatement(Statement):
+    # `obj.method(args)` used as its own statement - any return value is
+    # simply discarded.
+    def __init__(self,object_name,method_name,args):
+        self.expr = MethodCallExpression(object_name,method_name,args)
+
+    def execute(self):
+        self.expr.evaluate()
+
+
+class ListLiteral(Object):
+    # `[1, 2, 3]` - evaluates each element fresh every time (same as any
+    # other expression) into a plain Python list, which is what actually
+    # gets stored via a normal assignment. Elements are read the same way
+    # function-call arguments are (fetch_express() splitting on commas),
+    # so - like call arguments - each element needs to be a single value
+    # (a literal or variable), not a compound expression with its own
+    # operators.
+    def __init__(self,elements):
+        self.elements = elements
+
+    def evaluate(self):
+        return [e.evaluate() for e in self.elements]
+
+
+class LengthExpression(Object):
+    # `idadi orodha` - how many items are currently in a list.
+    def __init__(self,list_name):
+        self.list_name = list_name
+
+    def evaluate(self):
+        lst = _fetch_list(self.list_name)
+        return len(lst) if lst is not None else 0
+
+
+class IndexExpression(Object):
+    # `orodha[i]` used as a value - `x = orodha[i]` or `chapa orodha[i]`.
+    def __init__(self,list_name,index_expr):
+        self.list_name = list_name
+        self.index_expr = index_expr
+
+    def evaluate(self):
+        lst = _fetch_list(self.list_name)
+        if lst is None:
+            return None
+        index = self.index_expr.evaluate()
+        if symbolTable.exit() != 0:
+            return None
+        if not isinstance(index,int) or index < 0 or index >= len(lst):
+            Error.throwException('fahirisi',self.list_name)
+            return None
+        return lst[index]
+
+
+class IndexAssignmentStatement(Statement):
+    # `orodha[i] = <value>` - mutates an existing element in place.
+    def __init__(self,list_name,index_expr,value_expr):
+        self.list_name = list_name
+        self.index_expr = index_expr
+        self.value_expr = value_expr
+
+    def execute(self):
+        lst = _fetch_list(self.list_name)
+        if lst is None:
+            return
+        index = self.index_expr.evaluate()
+        value = self.value_expr.evaluate()
+        if symbolTable.exit() != 0:
+            return
+        if not isinstance(index,int) or index < 0 or index >= len(lst):
+            Error.throwException('fahirisi',self.list_name)
+            return
+        lst[index] = value
+
+
+class AppendStatement(Statement):
+    # `weka <value> kwenye orodha` - "put <value> into orodha", adding it
+    # to the end of the list.
+    def __init__(self,list_name,value_expr):
+        self.list_name = list_name
+        self.value_expr = value_expr
+
+    def execute(self):
+        lst = _fetch_list(self.list_name)
+        if lst is None:
+            return
+        value = self.value_expr.evaluate()
+        if symbolTable.exit() != 0:
+            return
+        lst.append(value)
+
+
+class RemoveStatement(Statement):
+    # `ondoa <index> kutoka orodha` - "remove <index> from orodha",
+    # discarding the item at that position and shifting the rest down,
+    # same as Python's `del lst[i]`.
+    def __init__(self,list_name,index_expr):
+        self.list_name = list_name
+        self.index_expr = index_expr
+
+    def execute(self):
+        lst = _fetch_list(self.list_name)
+        if lst is None:
+            return
+        index = self.index_expr.evaluate()
+        if symbolTable.exit() != 0:
+            return
+        if not isinstance(index,int) or index < 0 or index >= len(lst):
+            Error.throwException('fahirisi',self.list_name)
+            return
+        del lst[index]
+
+
+class FunctionDefinitionStatement(Statement):
+    def __init__(self,arg):
+        self.name = arg[0]
+        self.params = arg[1]
+        symbolTable.set_function(self.name)
+        Log('created new function {}'.format(self.name),'Function Definition')
+
+        #create new argument placeholders in the local variable scope
+        #immediately at parse/definition time, not in execute() - the
+        #definition itself may live outside kwanza (e.g. a helper
+        #function defined before main) and so may never be "executed"
+        #as a statement, but it must still be callable.
         for i in self.params:
-            Log('setting function parameter {}'.format(i.name))
-            Var(('function-{}-{}'.format(self.name, i.name), '', 'local')).evaluate()
-            
-        Log('{}'.format(symbolTable.table))
-            
-            
-class FunctionReturnStatement(Statement):
+
+            Var(('function-{}-{}'.format(self.name,i.name),'','local')).evaluate()
+
+            Log("created new argument: {}".format(i),'Function Definition')
+
+    def execute(self):
+        # Parameter placeholders are set up in __init__ (see above).
+        pass
+
+
+class InputStatement(Statement):
     
     def __init__(self,arg):
-        self.return_value = arg
         
-        
-    def execute(self):
-        #get current context (function name) and set the return value
-        symbolTable.set_return_value(symbolTable.get_scope("function-scope"),self.return_value)
-        
-        #self.return_value = self.return_value.evaluate()
-        
-        Log('{}'.format(self.return_value),'Evaluated return statement')
-        
-        Log('setting return value for function: {} to {}'.format(symbolTable.get_scope("function-scope"),self.return_value))
-        
-        #set our return value in the symbolTable (function_name,value)
-        symbolTable.set_return_value(symbolTable.get_scope("function-scope"),self.return_value)
-        p
-
-# Class to represent an input statement
-class InputStatement(Statement):
-    def __init__(self, arg):
-        # Prompt message for input
         self.value = arg[0].evaluate()
-        # Variable name to store the input value
+        
         self.storage = arg[1].name
-
+        
+        
+        
     def execute(self):
-        # Get input from the user
-        var = Object(TokenObj('string', input(str(self.value)), 0, 0, 0)).cast()
-        # Assign the input value to the specified variable
-        Var((self.storage, var, symbolTable.get_scope('var-scope'))).evaluate()
 
-# Class to represent an end block statement
-class EndBlockStatement(Statement):
-    def __init__(self, value):
-        # Value indicating the end of a block
-        self.value = value
-        # Reset the scope to the global variable scope and the function scope to the starting function
-        symbolTable.set_scope(('var-scope', 'global'))
-        symbolTable.set_scope(('function-scope', 'kwanza'))
+        raw = input(str(self.value))
 
-# Class to represent a print statement
-class PrintStatement(Statement):
-    def __init__(self, value):
-        # Value to be printed
-        self.value = value
+        # Auto-detect plain integers (e.g. from a numeric prompt like age)
+        # so the result can be used with comparisons/arithmetic in 'kama'
+        # blocks; anything else is kept as text.
+        token_type = 'integer' if raw.lstrip('-').isdigit() else 'string'
 
-    def execute(self):
-        # Print the value to console
-        if self.value.evaluate():
-            console.print_to_console('{}\n'.format(self.value.evaluate()))
-            Log("{}".format(self.value.evaluate()), "Print Statement")
-            
+        var = Object(TokenObj(token_type,raw,0,0,0)).cast()
+
+        # Same call_flag-based scope check as huku's loop variable (see
+        # ForStatement.execute()) - symbolTable.get_scope('var-scope') only
+        # reflects parse-time bookkeeping, which has already unwound by
+        # the time this runs.
+        var_scope = 'local' if symbolTable.call_flag else 'global'
+        symbolTable.write_variable(var_scope,self.storage,Literal(var.evaluate()))
+        
         
 
-# Class to represent an assignment statement
-class AssignmentStatement(Statement):
-    def __init__(self, value):
-        # Assigned value
+class IfStatement(Statement):
+    def __init__(self,arg):
+        self.true_name,self.condition = arg
+        self.else_name = None
+        symbolTable.set_function(self.true_name)
+        Log('created new if-block {}'.format(self.true_name),'If Definition')
+
+    def set_else(self,else_name):
+        self.else_name = else_name
+
+    def execute(self):
+        if self.condition.evaluate():
+            Log('condition true, executing if-block {}'.format(self.true_name),'If Execution')
+            for i in symbolTable.table['functions'][self.true_name]:
+                if symbolTable.exit() != 0 or symbolTable.is_returning():
+                    break
+                i.execute()
+        elif self.else_name is not None:
+            Log('condition false, executing sivyo-block {}'.format(self.else_name),'If Execution')
+            for i in symbolTable.table['functions'][self.else_name]:
+                if symbolTable.exit() != 0 or symbolTable.is_returning():
+                    break
+                i.execute()
+        else:
+            Log('condition false, no sivyo branch, skipping','If Execution')
+
+
+class WhileStatement(Statement):
+    # Safety valve: a runaway loop (e.g. forgetting to update the loop
+    # variable) would otherwise run forever with no way to stop it. This
+    # caps total iterations and fails gracefully instead.
+    MAX_ITERATIONS = 100000
+
+    def __init__(self,arg):
+        self.name,self.condition = arg
+        symbolTable.set_function(self.name)
+        Log('created new while-loop {}'.format(self.name),'While Definition')
+
+    def execute(self):
+        iterations = 0
+        while self.condition.evaluate():
+            if symbolTable.exit() != 0 or symbolTable.is_returning():
+                break
+            iterations = iterations + 1
+            if iterations > self.MAX_ITERATIONS:
+                Error.throwException('mzunguko',self.name)
+                break
+            for i in symbolTable.table['functions'][self.name]:
+                if symbolTable.exit() != 0 or symbolTable.is_returning():
+                    break
+                i.execute()
+            if symbolTable.is_returning():
+                break
+
+
+class ForStatement(Statement):
+    # 'huku <var> kutoka <start> hadi <end>' - a counted loop, for when you
+    # know how many times to repeat rather than watching a condition
+    # (that's what wakati is for). The end bound is exclusive, matching
+    # Python's range(): 'huku i kutoka 0 hadi 5' visits i = 0,1,2,3,4.
+    # If the end is lower than the start, it counts down instead of
+    # looping forever - 'huku i kutoka 5 hadi 0' visits i = 5,4,3,2,1.
+    MAX_ITERATIONS = 100000
+
+    def __init__(self,arg):
+        self.name,self.var_name,self.start,self.end = arg
+        symbolTable.set_function(self.name)
+        Log('created new for-loop {}'.format(self.name),'For Definition')
+
+    def execute(self):
+        start_val = self.start.evaluate()
+        end_val = self.end.evaluate()
+
+        if symbolTable.exit() != 0:
+            return
+
+        # Whether this loop variable should live in 'local' or 'global'
+        # storage depends on whether we're *currently executing* inside a
+        # function/method call - not on symbolTable.get_scope('var-scope'),
+        # which only reflects parse-time bookkeeping and, by the time
+        # execute() runs (well after parsing has fully finished), has
+        # already unwound back to its top-level default regardless of
+        # where this huku loop actually lives.
+        step = 1 if end_val >= start_val else -1
+        current = start_val
+        iterations = 0
+
+        while (current < end_val) if step == 1 else (current > end_val):
+            if symbolTable.exit() != 0 or symbolTable.is_returning():
+                break
+            iterations = iterations + 1
+            if iterations > self.MAX_ITERATIONS:
+                Error.throwException('mzunguko',self.name)
+                break
+
+            # Same storage path as a normal assignment (Var mode 1) -
+            # wrap the plain number in a Literal so later reads of the
+            # loop variable evaluate back out to it correctly. Isolated
+            # per-call the same way an ordinary local assignment is, so a
+            # loop variable inside a function can't shadow a same-named
+            # variable elsewhere in the script.
+            var_scope = 'local' if symbolTable.call_flag else 'global'
+            symbolTable.write_variable(var_scope,self.var_name,Literal(current))
+
+            for i in symbolTable.table['functions'][self.name]:
+                if symbolTable.exit() != 0 or symbolTable.is_returning():
+                    break
+                i.execute()
+
+            if symbolTable.is_returning():
+                break
+
+            current = current + step
+
+
+class ForEachStatement(Statement):
+    # 'huku <var> kwenye <list>' - iterates <var> over each item already
+    # in <list>, in order. Unlike the counted huku/wakati forms, there's
+    # no runaway-loop risk here (it's bounded by however many items the
+    # list has), so no MAX_ITERATIONS safety cap is needed. Iterates over
+    # a snapshot taken at the start, so appending to the same list from
+    # inside the loop body doesn't change how many passes this loop runs.
+    def __init__(self,arg):
+        self.name,self.var_name,self.list_name = arg
+        symbolTable.set_function(self.name)
+        Log('created new for-each loop {}'.format(self.name),'For-Each Definition')
+
+    def execute(self):
+        lst = _fetch_list(self.list_name)
+        if lst is None:
+            return
+
+        for item in list(lst):
+            if symbolTable.exit() != 0 or symbolTable.is_returning():
+                break
+
+            # See ForStatement.execute() - call_flag (not the stale
+            # parse-time var-scope) is what tells us whether this loop is
+            # currently running inside a function/method call.
+            var_scope = 'local' if symbolTable.call_flag else 'global'
+            symbolTable.write_variable(var_scope,self.var_name,Literal(item))
+
+            for i in symbolTable.table['functions'][self.name]:
+                if symbolTable.exit() != 0 or symbolTable.is_returning():
+                    break
+                i.execute()
+
+            if symbolTable.is_returning():
+                break
+
+
+class EndBlockStatement(Statement):
+    def __init__(self,value):
+        self.value = value
+        #pop back to whichever scope was active before this block opened
+        symbolTable.pop_scope()
+
+
+def format_value(value):
+    # Python's default str()/format() on a list reprs each element (so
+    # strings show up with quotes around them, e.g. "['Amara', 'Juma']"),
+    # which doesn't match how chapa prints a plain string (no quotes).
+    # Format lists element-by-element ourselves instead, recursively, so
+    # a list of strings prints the same unquoted way a lone string would.
+    if isinstance(value,list):
+        return '[' + ', '.join(format_value(v) for v in value) + ']'
+    return '{}'.format(value)
+
+
+def describe_type(value):
+    # Backs 'aina' ("kind/type") - a small teaching/debugging aid: what
+    # kind of value does this expression currently hold? bool is checked
+    # before int/float since Python's bool is itself a subclass of int
+    # (isinstance(True, int) is True), so it would otherwise be
+    # misreported as a number.
+    if isinstance(value,Instance):
+        return value.class_name
+    if isinstance(value,bool):
+        return 'boolean'
+    if isinstance(value,(int,float)):
+        return 'namba'
+    if isinstance(value,str):
+        return 'neno'
+    if isinstance(value,list):
+        return 'orodha'
+    return 'haijulikani'
+
+
+class TypeStatement(Statement):
+    # 'aina <expr>' - prints what kind of value an expression holds, e.g.
+    # 'namba' (number), 'neno' (text), 'boolean', 'orodha' (list), or the
+    # class name itself for a darasa instance.
+    def __init__(self,value):
         self.value = value
 
     def execute(self):
-        # Evaluate and assign the value to the variable
+        value = self.value.evaluate()
+        if symbolTable.exit() == 0:
+            if console is not None:
+                console.insert(tk.END,'{}\n'.format(describe_type(value)))
+            else:
+                print(describe_type(value))
+            Log("{}".format(describe_type(value)),"Type Statement")
+
+
+class PrintStatement(Statement):
+    def __init__(self,value):
+        self.value = value
+
+    def execute(self):
+        # Evaluate first, then gate on whether that evaluation itself
+        # raised an error (e.g. an undefined variable, which sets the
+        # exit flag) - not on the value's truthiness. The old
+        # `if self.value.evaluate():` meant chapa silently printed
+        # nothing at all for legitimate 0/false/"" values.
+        value = self.value.evaluate()
+        if symbolTable.exit() == 0:
+            if console is not None:
+                console.insert(tk.END,'{}\n'.format(format_value(value)))
+            else:
+                print(format_value(value))
+            Log("{}".format(format_value(value)),"Print Statement")
+        
+
+class AssignmentStatement(Statement):
+    def __init__(self,value):
+        self.value = value
+
+
+    def execute(self):
         self.value.evaluate()
 
-#class to represent a return-object-type statement        
-class ReturnObjectTypeStatement(Statement):
-    def __init__(self, value):
-        # Assigned value
-        self.value = value
+
+class ReturnStatement(Statement):
+    # 'rudisha' - stops the current function immediately (a bare rudisha
+    # is a guard-clause style early exit) and optionally carries a value
+    # back out. Doesn't unwind anything itself - it just records the
+    # value and sets symbolTable's return flag; every enclosing kama/
+    # wakati/huku loop checks that flag and breaks out on its own, all
+    # the way up to FunctionCallStatement.execute(), which is what
+    # actually absorbs it and hands the value back to the caller.
+    def __init__(self,expr):
+        self.expr = expr
 
     def execute(self):
-        # Evaluate and assign the value to the variable
-        #self.value.evaluate()
-        print(self.value.return_type())
+        if symbolTable.exit() != 0:
+            return
+        value = self.expr.evaluate() if self.expr is not None else None
+        if symbolTable.exit() != 0:
+            return
+        symbolTable.set_return(value)
 
-            
-        
-        
+
 '''
 
+    def parse_next_expression(self):
+        
+        results = None
+        
+        expressions = [] 
+        
+        value = self.next_token().value if self.next_token().token_type != 'variable' else getattr(sys.modules['__main__'], self.value)
+        
+        
+        
+        while(self.get_token_by_index(self.token_position + 2).token_type == 'operator'):
+            val_ = self.get_token_by_index(self.token_position + 2).value
+            next_val = self.get_token_by_index(self.token_position + 3).value 
+            
+            if val_ == '+' :
+                value = value + next_val if next_val != 'variable' else getattr(sys.modules['__main__'], next_val)
+                self.token_position = self.token_position + 
 
-
-   - The code defines a global dictionary variable named "variables" that stores information about variables, functions, and classes.
-   - It initializes this dictionary with empty "global" and "local" variables, an empty list of functions, and an empty list of classes.
-
-
-   - The code defines a global variable named "console" and initializes it as None.
-
-Context and Flags:
-   - The code defines a global dictionary variable named "context" that stores the current context of the program, such as variable and function scopes.
-   - It also defines two global flags: "definition_flag" and "call_flag" to track function and variable definitions and function calls, respectively.
-
-StatementParser Class:
-   - The code defines a class named "StatementParser" that handles the parsing and execution of Hamri statements.
-   - It initializes the class with a list of tokens representing the Hamri script.
-   - The class provides methods for parsing different types of statements and executing them.
-   - The "parseStatement" method takes a token as input, determines the type of statement, and parses it accordingly.
-   - The "fetch_express" method is used to fetch expressions from the tokens.
-   - The "next_token" and "prev_token" methods return the next and previous tokens, respectively.
-   - The "parse" method parses all the statements in the script.
-   - The "execute" method executes the parsed statements.
-
-Statement Class:
-   - The code defines a base class named "Statement" that serves as the parent class for different types of statements in Hamri.
-
-FunctionCallStatement Class:
-   - The code defines a class named "FunctionCallStatement" that represents a function call statement in Hamri.
-   - It takes the function name and its parameters as input.
-   - The "execute" method assigns parameter values to function arguments and executes the function's statements.
-
-FunctionDefinitionStatement Class:
-   - The code defines a class named "FunctionDefinitionStatement" that represents a function definition statement in Hamri.
-   - It takes the function name and its parameters as input.
-   - The "execute" method creates new argument variables for the function.
-
-InputStatement Class:
-    - The code defines a class named "InputStatement" that represents an input statement in Hamri.
-    - It takes the input message and the variable to store the input value as input.
-    - The "execute" method prompts the user for input and assigns the entered value to the specified variable.
-
-EndBlockStatement Class:
-    - The code defines a class named "EndBlockStatement" that represents the end of a block (function or script) in Hamri.
-    - It takes the current context as input and resets the variable and function scopes.
-
-PrintStatement Class:
-    - The code defines a class named "PrintStatement" that represents a print statement in Hamri.
-    - It takes the value to be printed as input.
-    - The "execute" method evaluates the value and prints it.
-
-13. AssignmentStatement Class:
-    - The code defines a class named "AssignmentStatement" that represents an assignment statement in Hamri.
-    - It takes the variable name and its assigned value as input.
-    - The "execute" method evaluates the assigned value and assigns it to the variable.
-
-Explanation:
-    - The code includes comments throughout the script explaining various parts and functionalities.
-
-Execution:
-    - The code checks if there is a console (text widget) provided and inserts execution logs and output into it.
-    - The "parse" method is called to parse all the statements in the script.
-    - The "execute" method is called to execute the parsed statements.
-    - After execution, an exit code is logged and displayed in the console (if provided).
-    
-    
 '''

--- a/SymbolTable.py
+++ b/SymbolTable.py
@@ -2,193 +2,297 @@ from Logger import Log
 
 class SymbolTable:
     def __init__(self):
-        # Initialize the symbol table with empty dictionaries for variables, functions, and classes
         self.table = {
             "variables" :{
                 "global":{},
                 "local":{}
             },
             "functions":{
-                "kwanza":[]
+                # 'kwanza' ("first") is the required main block - only
+                # statements inside an explicit kwanza...kwisha run.
+                # 'nje' ("outside") holds anything parsed before/outside
+                # kwanza - e.g. helper function definitions - which is
+                # never auto-executed, only called into from 'kwanza'.
+                "kwanza":[],
+                "nje":[]
             },
             "classes":{
-                "kwanza":[]
+                # Simple presence-registry populated by 'darasa' - maps a
+                # class name to True, purely so a call like `Mtu(args)`
+                # can tell "this name is a class, construct an instance"
+                # apart from "this name is a function, call it".
             }
         }
-        
-        # Initialize the context with default values for variable scope, function scope, and class scope
-        self.context =  {"var-scope": "global", "function-scope": "kwanza", "class-scope": "kwanza"}
-        
-        # Initialize flags for function definition, function call, and program exit
+        self.context =  {"var-scope": "global","function-scope":"nje","class-scope":"kwanza"}
+
+        # Stack of (function-scope, var-scope) pairs, pushed when entering
+        # a block (kwanza/eleza/kama) and popped on 'kwisha', so nested
+        # blocks correctly return to their *enclosing* scope instead of
+        # always resetting to the top level.
+        self.scope_stack = []
+
         self.def_flag = False
+
         self.call_flag = False
+
+        # Stack of currently-executing call names (function/method
+        # qualified names), innermost last. call_flag always mirrors the
+        # top of this stack - kept as a separate attribute since it's
+        # already read all over the place (fetch_variable, local_key).
+        # Needed so that when a nested call finishes (e.g. function A
+        # calls function B), execution correctly resumes "inside A" -
+        # rather than unconditionally forgetting there was ever an
+        # active call at all - so any of A's own local variables written
+        # *after* the call to B still land back in A's own call-qualified
+        # storage instead of leaking into globals.
+        self.call_stack = []
+
         self.exit_flag = 0
-        
-    def reset_table(self):
-        self.table ={
-            "variables" :{
-                "global":{},
-                "local":{}
-            },
-            "functions":{
-                "kwanza":[]
-            },
-            "classes":{
-                "kwanza":[]
-            }
-        }
-        
+
+        # Shared handle to whatever 'console' object the current run is
+        # using (a Tk Text widget in the desktop Notepad, or None for
+        # plain CLI use, in which case output falls back to a bare
+        # print()). Lets Errors.py surface messages the same way chapa
+        # does.
+        self.console = None
+
+        # Pluggable hook used by 'leta' (import) to fetch another
+        # module's source text by name - a callable taking a filename and
+        # returning its source (or None if not found). Left as None,
+        # load_module_source() falls back to reading a real file off
+        # disk, so a plain script (e.g. via main.py) can 'leta' from a
+        # sibling .ham file. A host embedding this interpreter elsewhere
+        # (e.g. a GUI with its own in-memory files) can override this to
+        # resolve module names however makes sense there instead.
+        self.module_loader = None
+
+        # Set by 'rudisha' (return) so every enclosing block loop (kama,
+        # wakati, huku) knows to stop running further statements and
+        # unwind, all the way up to the function-call boundary - the one
+        # place (FunctionCallStatement.execute) that actually absorbs the
+        # flag and reads return_value, so it never leaks past the
+        # function that returned into the caller's own control flow.
+        self.return_flag = False
+        self.return_value = None
+
+        # Ever-increasing counter handing out a unique id to every object
+        # created via a 'darasa' class, so each instance gets its own
+        # distinct storage key even across multiple objects of the same
+        # class.
+        self.next_instance_id = 1
+
+
+    def new_instance_id(self):
+        id_ = self.next_instance_id
+        self.next_instance_id = self.next_instance_id + 1
+        return id_
+
+    def set_class(self,name):
+        self.table['classes'][name] = True
+
+    def load_module_source(self,filename):
+        # Used by 'leta' to fetch another file's Hamri source by name.
+        # See module_loader above - the host environment can override
+        # how a filename resolves to source text; without one, fall back
+        # to a plain local file read so a script run from disk can still
+        # 'leta' a sibling file.
+        if self.module_loader is not None:
+            return self.module_loader(filename)
+        try:
+            with open(filename,'r') as f:
+                return f.read()
+        except (IOError,OSError):
+            return None
+
+    def alias_function(self,new_name,original_name):
+        # Backs 'leta's selective method import ('leta salamu kutoka Mtu
+        # kutoka "faili"') - copies an already-parsed function/method's
+        # body and parameter placeholders under a new bare name, so it
+        # can be called standalone (e.g. `salamu(...)`) exactly like any
+        # other function. Deliberately does NOT copy a '-nafsi' binding -
+        # a method pulled out of its class this way has no instance to
+        # bind 'nafsi' to, so if its body still reaches for nafsi.anything
+        # it'll fail the same way referencing any other undefined
+        # variable would (Kosa La Anwani), rather than silently doing the
+        # wrong thing. Returns False (no error thrown here - the caller
+        # decides how to report it) if the original function doesn't
+        # exist at all.
+        if original_name not in self.table['functions']:
+            return False
+
+        self.table['functions'][new_name] = self.table['functions'][original_name]
+
+        old_prefix = 'function-{}-'.format(original_name)
+        new_prefix = 'function-{}-'.format(new_name)
+        for key in list(self.table['variables']['local'].keys()):
+            if key.startswith(old_prefix) and not key.endswith('-nafsi'):
+                suffix = key[len(old_prefix):]
+                self.table['variables']['local'][new_prefix + suffix] = self.table['variables']['local'][key]
+
+        return True
+
+    def set_return(self,value):
+        self.return_flag = True
+        self.return_value = value
+
+    def clear_return(self):
+        self.return_flag = False
+        self.return_value = None
+
+    def is_returning(self):
+        return self.return_flag
+
     def reset_flags(self):
-        # Reset the function definition and function call flags
         self.def_flag = False
+        
         self.call_flag = False
         
-    def en_flag(self, arg, value=True):
-        # Enable a specific flag (function call or function definition) with the given value
+    def en_flag(self,arg,value=True):
+
         if arg == 'call':
-            #if it is a function being called, set the call flag
+            self.call_stack.append(value)
             self.call_flag = value
+
         else:
-            #a function is being defined so set the definition flag
             self.def_flag = value
+
+    def pop_call(self):
+        # Ends the innermost active call, restoring call_flag to whichever
+        # call (if any) was running before it - see call_stack above.
+        if self.call_stack:
+            self.call_stack.pop()
+        self.call_flag = self.call_stack[-1] if self.call_stack else False
+
+    def local_key(self,name):
+        # Qualifies a variable name to the currently-executing function/
+        # method call, if any, exactly the same way function parameters
+        # already are ('function-{call}-{param}') - so an ordinary local
+        # variable assigned inside a function body (anything that isn't
+        # one of its declared parameters) gets its own isolated storage
+        # slot per call, instead of every function in the whole program
+        # sharing one flat bare-name entry in 'local'. fetch_variable()
+        # already checks this qualified form first whenever call_flag is
+        # set, so no changes were needed there.
+        return 'function-{}-{}'.format(self.call_flag,name) if self.call_flag else name
+
+    def write_local(self,name,value):
+        self.table['variables']['local'][self.local_key(name)] = value
+
+    def write_variable(self,scope,name,value):
+        # Central write path for a variable assignment - used by ordinary
+        # '=' assignment (Var.evaluate) as well as huku/for-each loop
+        # variables and jaza input, so all of them get the same per-call
+        # isolation instead of only function parameters getting it.
+        if scope == 'local':
+            self.write_local(name,value)
+        else:
+            self.table['variables'][scope][name] = value
+
+    def fetch_variable(self,key):
         
-    def fetch_variable(self, key):
-        # Retrieve the value of a variable with the given key
-        
-        Log('fetching.......: ' + key)
+        Log('fetching.......: '+key)
         
         return_val = None
         
-        #check first if its a function being called, in this case, the variable is a parameter of the function
         
-        if self.call_flag and 'function-{}-{}'.format(self.call_flag, key) in self.table['variables']['local'].keys():
-            # Variable found in function's local scope
+        if self.call_flag and 'function-{}-{}'.format(self.call_flag,key) in self.table['variables']['local'].keys():
             Log('found in function local scope')
-            val = 'function-{}-{}'.format(self.call_flag, key)
+            val = 'function-{}-{}'.format(self.call_flag,key)
             return_val = self.table['variables']['local'][val]
         elif key in self.table['variables']['local'].keys():
-            # Variable found in local scope
             Log('found in local scope')
             return_val = self.table['variables']['local'][key]
         elif key in self.table['variables']['global'].keys():
-            # Variable found in global scope
             Log('found in global scope')
             return_val = self.table['variables']['global'][key]
         else:
-            # Variable not found
             return_val = False
-        
+            
         Log('result.......: {}'.format(return_val))    
         return return_val
     
-    def exit(self, arg='get'):
-        # Get or set the exit flag of the program
+    def exit(self,arg='get'):
         
-        result = False
+        res = False
         
         if arg == 'get':
-            # Return the current exit flag value
-            result = self.exit_flag
+            res = self.exit_flag
         else:
-            # Set the exit flag to the given value
             self.exit_flag = arg
-            result = True 
+            res = True 
             
-        return result
+        return res
+        
+            
+        
     
-    def set_variable(self, obj):
-        # Set a variable with the given name, value, and scope
+    def set_variable(self,obj):
         
-        name, value, scope = obj
+        name,value,scope = obj
         
-        self.table['variables'][scope][name] = value
+        self.table['variables'][scope][i] = ''
         
-    def set_function(self, arg):
-        # Set a function with the given name in the symbol table
+    def set_function(self,arg):
         
+         
         self.table['functions'][arg] = []
         
-    def get_function_arguments(self, arg):
-        # Get the arguments of a function with the given name
-        
+    def get_function_arguments(self,arg):
+
         res = []
-        
-        ## Issue: Could combine all this into one long list comprehension. Current code is not efficient
-        
+
         keys = [k for k in self.table['variables']['local'].keys()]
-        
+
         for k in keys:
-            if k.startswith('function-{}-'.format(arg)):
-                # Found an argument of the function
+            # '-nafsi' is 'self' for a method call, bound the same way a
+            # normal parameter is (see FunctionCallStatement) but isn't
+            # one of the function's own declared parameters, so it must
+            # never be zipped against the caller's actual argument list.
+            if k.startswith('function-{}-'.format(arg)) and not k.endswith('-nafsi'):
+
                 res.append(k)
-        #only return if more than one argument
-        return res if len(res) > 0 else []
-    
-    def set_scope(self, arg):
-        # Set the value of a specific scope (variable scope, function scope, or class scope)
+
+
+
+        return res if len(res)>0 else []
         
-        name, value = arg
         
+        
+    def set_scope(self,arg):
+
+        name,value = arg
+
         self.context[name] = value
-        
-    def get_scope(self, arg):
-        # Get the value of a specific scope (variable scope, function scope, or class scope)
-        
+
+    def get_scope(self,arg):
+
         return self.context[arg]
-        
-        
+
+    def push_scope(self,function_scope,var_scope=None):
+        # Remember the current (enclosing) scope, then switch into the
+        # new block. var_scope is only overridden for blocks that need
+        # their own fresh variable scope (functions); kama/kwanza share
+        # whatever variable scope was already active.
+        self.scope_stack.append((self.context['function-scope'],self.context['var-scope']))
+        self.context['function-scope'] = function_scope
+        if var_scope is not None:
+            self.context['var-scope'] = var_scope
+
+    def pop_scope(self):
+        if self.scope_stack:
+            function_scope,var_scope = self.scope_stack.pop()
+            self.context['function-scope'] = function_scope
+            self.context['var-scope'] = var_scope
+        else:
+            # Stray/unmatched kwisha - fall back to the safe top-level default.
+            self.context['function-scope'] = 'nje'
+            self.context['var-scope'] = 'global'
+
+    def reset(self):
+        # Clears all variables/functions/if-blocks and flags so a fresh
+        # script run (e.g. clicking "Execute" again in the desktop
+        # Notepad) doesn't inherit state left over from a previous run.
+        self.__init__()
+
+
 symbolTable = SymbolTable()
-
-
-# The provided code implements a Symbol Table, which is a data structure used by compilers and interpreters
-# to store and manage information about variables, functions, and classes in a programming language.
-
-
-# Importing the Log class from the Logger module.
-
-# The SymbolTable class is defined, which represents the symbol table.
-
-# The __init__ method initializes the symbol table with empty dictionaries for variables, functions, and classes.
-
-# The 'table' dictionary has the following structure:
-# "variables": Contains dictionaries for global and local variables.
-# "functions": Contains a dictionary of function names and their associated arguments.
-# "classes": Contains a dictionary of class names.
-
-# The 'context' dictionary is initialized with default values for variable scope, function scope, and class scope.
-# It keeps track of the current scope in the symbol table.
-
-# The 'def_flag', 'call_flag', and 'exit_flag' variables are initialized as flags for function definition,
-# function call, and program exit, respectively.
-
-# The 'reset_flags' method is used to reset the function definition and function call flags.
-
-# The 'en_flag' method is used to enable a specific flag (function call or function definition) with the given value.
-
-# The 'fetch_variable' method retrieves the value of a variable with the given key. It checks the current scope,
-# starting from the local scope, then the global scope. If the variable is not found, it returns False.
-
-# The 'exit' method is used to get or set the exit flag of the program. If called without an argument,
-# it returns the current exit flag value. If called with an argument, it sets the exit flag to the given value.
-
-# The 'set_variable' method is used to set a variable with the given name, value, and scope.
-# It adds the variable to the appropriate scope in the symbol table.
-
-# The 'set_function' method is used to set a function with the given name in the symbol table.
-# It adds an empty list for the function in the "functions" dictionary.
-
-# The 'get_function_arguments' method retrieves the arguments of a function with the given name.
-# It searches for variables in the local scope that have names starting with "function-{function_name}-",
-# indicating they are function arguments.
-
-# The 'set_scope' method is used to set the value of a specific scope (variable scope, function scope, or class scope)
-# in the 'context' dictionary.
-
-# The 'get_scope' method is used to get the value of a specific scope from the 'context' dictionary.
-
-# Finally, an instance of the 'SymbolTable' class is created and assigned to the 'symbolTable' variable.
-
-# The Symbol Table is a fundamental component of language processing systems, as it allows for the storage and retrieval
-# of information about variables, functions, and classes during the compilation or interpretation process.
-# It enables proper scoping and lookup of symbols, ensuring correct handling of identifiers in a programming language.
-

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import sys
+
 from LexicalParser import LexicalParser
 from StatementParser import StatementParser
 from Logger import Logs,LogKeys
@@ -5,27 +7,54 @@ path_ = 'path_to_hamri_file'
 
 ##Note: hamri script files end in the extension ' .ham '
 
-##Here is a sample Hamri script
+##Here is a sample Hamri script - showing off some of the language's
+##newer features (loops, lists, classes) alongside the original demo
 
 code = '''
+
+darasa Mtu
+
+    eleza jenga(jina)
+
+        nafsi.jina = jina
+
+    kwisha
+
+    eleza salamu()
+
+        rudisha "Hello world. I am " + nafsi.jina
+
+    kwisha
+
+kwisha
+
+eleza sayHi(name)
+
+    chapa "Hello world. " + "I am " + name
+
+kwisha
 
 kwanza
 
     hamri_v = "Hamri v1.02"
 
-    eleza sayHi(name)
-
-        chapa "Hello world. " + "I am " + name
-
-    kwisha
-
-
     sayHi(hamri_v)
 
     chapa 10 / 2
 
-    aina(hamri_v)
+    aina hamri_v
 
+    mtu1 = Mtu(hamri_v)
+
+    chapa mtu1.salamu()
+
+    orodha = [1, 2, 3]
+
+    huku item kwenye orodha
+
+        chapa item
+
+    kwisha
 
 kwisha
 
@@ -35,10 +64,21 @@ kwisha
 
 
 if __name__ == '__main__':
-    #lexicalParser = LexicalParser(path_,'f').parse() #add 'f' flag for file paths
-    lexicalParser = LexicalParser(code).parse()
+    # Console mode: `python3 main.py` runs the built-in sample script
+    # above; `python3 main.py path/to/script.ham` runs that file instead.
+    #
+    # LexicalParser's second argument, from_text, controls how the first
+    # argument is read: from_text=True treats it as literal Hamri source
+    # text (as used for `code` above); leaving it out (the default,
+    # from_text=False) treats the first argument as a path to a script
+    # file on disk instead - which is exactly what we want for the
+    # command-line-argument case below.
+    if len(sys.argv) > 1:
+        lexicalParser = LexicalParser(sys.argv[1]).parse()
+    else:
+        lexicalParser = LexicalParser(code, from_text=True).parse()
     #print to console all the tokens found in script
-    #lexicalParser.print_tokens() 
+    #lexicalParser.print_tokens()
     statementParser = StatementParser(lexicalParser.token_list).parse()
     #print to console all the statements parsed from the tokens found
     #statementParser.print_statements()


### PR DESCRIPTION
## Summary

This PR brings the interpreter up to date with a substantial language
feature expansion and a set of correctness fixes, plus quality-of-life
improvements to the desktop IDE (`Notepad.py`) and documentation. Full
details are in `CHANGELOG.md`.

## New language features

- `sivyo` — else branch for `kama`
- `wakati` — while loop
- `huku` — counted for-loop (`kutoka`/`hadi`) and for-each loop (`kwenye`)
- `rudisha` — return statement, unwinds correctly through nested blocks
- Word-form operators: `ongeza`, `punguza`, `mara`, `gawa`, `sawa`,
  `kabisa`/`hakika`
- `#` comments (quote-aware)
- Lists (`orodha`): literals, indexing, `weka`, `idadi`, `ondoa`, nesting
- Classes (`darasa`): methods, `nafsi` (self), `jenga` constructor, dot
  notation for properties/methods
- `leta` — import a class (or a comma list of classes), or one specific
  method of a class, from another `.ham` file
- `aina` — proper type introspection (replaces a previously dead,
  non-functional implementation)

## Bug fixes

- `kama` conditionals actually execute (previously a no-op)
- Square brackets are now tokenized (were silently skipped)
- Token matching uses a full match instead of a substring search
- Boolean literals evaluate correctly (`"false"` no longer truthy)
- Self-referential assignment (`i = i + 1`) no longer infinite-loops
- Undefined function calls report a clean error instead of a raw
  Python `KeyError`
- Local variables are now isolated per function/method call
- Multi-operand expression chains with more than one "special value"
  (function call, property read, list index) evaluate correctly
- Running with no console attached (plain CLI) now falls back to
  `print()` instead of producing no output at all

## Notepad.py (desktop IDE)

- Added "Run ▶", "Clear Editor", and "Clear Console" — as in-window
  buttons and File menu items — plus a `Cmd+R`/`Ctrl+R` shortcut, so
  running a script doesn't depend on macOS's system menu bar rendering
  correctly
- Fixed a crash when pasting into the editor with nothing selected

## Repository cleanup

- Removed the old PHP-based website shell, the `ui/` HTML/JS prototype,
  and local dev-environment scaffolding (Lando/DDEV configs). The repo
  is now a plain, dependency-free Python codebase.

## Docs

- Rewrote `README.md` as a full language reference (keywords, types,
  every construct with runnable examples, error messages, known
  limitations) plus run instructions for both console and IDE mode
- Expanded `CHANGELOG.md` with complete details on every change above

## Testing

Verified via a manual test harness exercising the interpreter directly
(classes/OOP, `aina`, lists, `wakati`/`huku`, `rudisha`, `leta` imports)
and by running both `main.py`'s built-in demo and custom `.ham` files
end to end. All Python files compile cleanly.

## Known follow-ups (not in this PR)

- `run.py` and `Logger.py.testcopy` are stray leftovers, untracked and
  safe to delete separately
- `Notepad.py`'s live syntax highlighting (`__generateTags`) has a
  pre-existing bug unrelated to this change; only script execution was
  fixed