### PR TITLE
Fix jaza terminal-blocking and Notepad syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — language feature expansion + interpreter fixes
+## v1.0.3 — language feature expansion + interpreter fixes
 
 This is a large update that brings the interpreter up to date with an
 extended, independently-developed fork of Hamri (originally built out
@@ -188,11 +188,52 @@ document the language and confirms it still executes successfully.
   number literals, no inheritance or static/shared class variables, no
   chained list indexing (`matrix[0][1]` — index into an intermediate
   variable instead), and `ondoa` removes by position, not by value.
-- `Notepad.py`'s live syntax-highlighting (`__generateTags`) was already
-  non-functional before this change (it compares `token.type` — a bound
-  method, not the token's type string — against capitalized category
-  names that don't correspond to any of the lexer's actual token types,
-  and passes raw character offsets to Tkinter APIs that expect
-  `"line.column"` index strings). Left as-is; only the code-execution
-  path (`__execute()`) was fixed, since that's what was actually broken
-  by this change specifically.
+
+### Desktop IDE follow-up fixes
+
+Two rough edges called out (but deliberately left unfixed) earlier in
+this same release are now actually fixed too, along with a related
+lexer bug the highlighting fix surfaced along the way.
+
+- **`jaza` no longer silently blocks on the terminal when run through
+  the desktop Notepad.** Previously `InputStatement.execute()` always
+  called Python's built-in `input()` directly, so a script using `jaza`
+  and run via `Notepad.py` would appear to hang — it was actually
+  waiting on stdin in whatever terminal launched the IDE, easy to miss
+  entirely. `SymbolTable` now has a pluggable `input_handler` hook
+  (mirroring the existing `module_loader` hook `leta` uses) - `jaza`
+  calls `symbolTable.read_input(prompt)`, which uses the hook if one's
+  set, and falls back to plain `input()` otherwise (so `main.py` is
+  unaffected). `Notepad.py` wires this to a proper
+  `tkinter.simpledialog.askstring` dialog.
+- **Fixed `Notepad.py`'s live syntax highlighting (`__generateTags`),**
+  previously entirely non-functional: it compared `token.type` — a
+  *method* on `TokenObj`, not the token's type string (`token.token_type`
+  is the actual attribute) — against capitalized category names
+  (`"Keyword"`, `"Identifier"`, etc.) that don't match any of the
+  lexer's real, lowercase token types (`keyword`, `variable`, `operator`,
+  `boolean`, `integer`, `string`) at all, so no branch ever matched and
+  no token was ever colored. It also passed raw character offsets
+  straight to `tag_add()`, which expects Tkinter's own `"line.column"`
+  index strings, not plain offsets. Both are now fixed: correct type
+  comparison, correct index conversion, and tags are re-applied (not
+  recreated) on every edit.
+- **Fixed a related lexer bug the above surfaced**: a `string` token's
+  `value` has its surrounding quote characters stripped off (so the
+  interpreter sees the bare text, not the quotes) — but `TokenObj`
+  computed its length from that same already-stripped value, so it came
+  out 2 characters short of the token's actual span in the source. This
+  didn't affect execution (nothing on the interpretation path reads a
+  token's length or span), but it meant highlighting a string literal
+  stopped 2 characters early. `TokenObj` now takes an explicit
+  `raw_length` (the un-stripped match length), so `.size()`/`.span()`
+  reflect the real source position for every token type.
+
+## v1.0.2 — initial commit
+
+The starting point this changelog's v1.0.3 entry above is measured
+against: the original interpreter (`LexicalParser` → `StatementParser` →
+`Objects`/`ExpressionParser`/`SymbolTable`/`Errors`), `main.py`, and the
+`Notepad.py` desktop IDE, supporting `kwanza`/`kwisha`, `chapa`, `jaza`,
+`eleza`, and a partially-wired `kama`/`aina`, tagged retroactively as a
+version marker for the baseline this project started from.

--- a/LexicalParser.py
+++ b/LexicalParser.py
@@ -154,6 +154,13 @@ class LexicalParser:
 
                token_type = t.name
                value = t_[0]
+               # How many characters this token actually occupies in the
+               # source line - captured before any of the substitutions
+               # below (quote-stripping, word-operator swaps) shorten
+               # 'value' itself, so TokenObj's position/highlighting
+               # methods (span()/size()) still line up with the real
+               # source text rather than whatever 'value' ends up as.
+               raw_length = len(value)
 
                # Word-form operators (inazidi/haizidi/ni) tag as 'keyword'
                # like any other reserved word, but the rest of the
@@ -169,7 +176,8 @@ class LexicalParser:
                self.token_list.append(
                   TokenObj(token_type,
                         value.replace('"','').replace('\'','') if token_type == 'string' else value,#remove string quotes statements
-                        t_[1],t_[2],id_
+                        t_[1],t_[2],id_,
+                        raw_length=raw_length
                         )
                   )
                break
@@ -225,13 +233,23 @@ class LexicalParser:
 
    
 class TokenObj:
-   def __init__(self, token_type, value,start,line,offset):
+   def __init__(self, token_type, value,start,line,offset,raw_length=None):
       self.token_type = token_type
       self.value = value
       self.line = line
       self.start = start
       self.offset = offset
-      self.len_ = len(self.value)
+      # raw_length is how many characters this token actually occupies in
+      # the original source line (start:start+raw_length) - normally
+      # identical to len(value), EXCEPT for a 'string' token, whose value
+      # has its surrounding quote characters stripped off (see
+      # LexicalParser.parse()) so the interpreter gets the bare text
+      # rather than the quotes themselves. Without this, len_ would come
+      # out 2 short of the token's real span for every string literal -
+      # harmless for interpretation (nothing execution-related reads
+      # size()/span()), but wrong for anything that maps a token back
+      # onto a position in the source, like syntax highlighting.
+      self.len_ = raw_length if raw_length is not None else len(self.value)
    def value(self):
       return self.value
    

--- a/Notepad.py
+++ b/Notepad.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import *
 from tkinter.messagebox import *
 from tkinter.filedialog import *
+from tkinter.simpledialog import askstring
 import webbrowser
 from tkinter import ttk
 import os
@@ -129,37 +130,63 @@ class Notepad:
         self.__root.bind_all("<Command-r>", lambda event: self.__execute())
         self.__root.bind_all("<Control-r>", lambda event: self.__execute())
 
+    # Maps each of the lexer's actual token type strings (see the `Tokens`
+    # enum in LexicalParser.py - 'keyword', 'variable', 'operator',
+    # 'divider', 'boolean', 'integer', 'string') to one of the four
+    # highlight tags below. Previously this compared against
+    # "Keyword"/"Identifier"/"Operator"/"Literal" - capitalized names that
+    # don't match any of the lexer's real (lowercase) token types at all,
+    # so no token was ever colored. 'divider' (brackets/parens/dot) is
+    # deliberately left unmapped - punctuation, not worth its own color.
+    _TOKEN_TAGS = {
+        'keyword': 'Token.Keyword',
+        'variable': 'Token.Identifier',
+        'operator': 'Token.Operator',
+        'boolean': 'Token.Literal',
+        'integer': 'Token.Literal',
+        'string': 'Token.Literal',
+    }
+
     def __generateTags(self, event=None):
         """Generates tags for syntax highlighting"""
-        # Clear existing tags
-        self.__thisTextArea.tag_delete("Token.Keyword")
-        self.__thisTextArea.tag_delete("Token.Identifier")
-        self.__thisTextArea.tag_delete("Token.Operator")
-        self.__thisTextArea.tag_delete("Token.Literal")
+        # Remove previous highlighting (tag_remove clears the ranges but
+        # keeps the tag's style configured below, rather than deleting
+        # and recreating the tag on every keystroke).
+        for tag in ("Token.Keyword", "Token.Identifier", "Token.Operator", "Token.Literal"):
+            self.__thisTextArea.tag_remove(tag, "1.0", "end")
+
+        self.__thisTextArea.tag_configure("Token.Keyword", foreground="blue", font=("Courier", 12, "bold"))
+        self.__thisTextArea.tag_configure("Token.Identifier", foreground="black", font=("Courier", 12, "normal"))
+        self.__thisTextArea.tag_configure("Token.Operator", foreground="green", font=("Courier", 12, "normal"))
+        self.__thisTextArea.tag_configure("Token.Literal", foreground="purple", font=("Courier", 12, "normal"))
 
         # Parse code and generate tokens. from_text=True is required here -
         # without it, LexicalParser treats its argument as a *file path* by
         # default (see main.py) rather than literal source text, which
         # would raise on every keystroke since this text isn't a real file.
         code = self.__thisTextArea.get("1.0", "end-1c")
-        lexer = LexicalParser(code, from_text=True).parse()
+        try:
+            lexer = LexicalParser(code, from_text=True).parse()
+        except Exception:
+            # Mid-edit source (e.g. an unterminated string) shouldn't be
+            # able to raise out of a text-modified event handler - just
+            # skip highlighting for this keystroke and try again on the
+            # next one.
+            return
         self.__Tokens = lexer.token_list
-        
 
-        # Configure tags for different token types
         for token in self.__Tokens:
-            if token.type == "Keyword":
-                self.__thisTextArea.tag_add("Token.Keyword", token.start, token.end)
-                self.__thisTextArea.tag_configure("Token.Keyword", foreground="blue", font=("Courier", 12, "bold"))
-            elif token.type == "Identifier":
-                self.__thisTextArea.tag_add("Token.Identifier", token.start, token.end)
-                self.__thisTextArea.tag_configure("Token.Identifier", foreground="black", font=("Courier", 12, "normal"))
-            elif token.type == "Operator":
-                self.__thisTextArea.tag_add("Token.Operator", token.start, token.end)
-                self.__thisTextArea.tag_configure("Token.Operator", foreground="green", font=("Courier", 12, "normal"))
-            elif token.type == "Literal":
-                self.__thisTextArea.tag_add("Token.Literal", token.start, token.end)
-                self.__thisTextArea.tag_configure("Token.Literal", foreground="purple", font=("Courier", 12, "normal"))
+            tag = self._TOKEN_TAGS.get(token.token_type)
+            if tag is None:
+                continue
+            # Tkinter Text indices are "line.column" strings, with lines
+            # 1-indexed - token.line/token.start are plain 0-indexed
+            # character offsets within the source (see TokenObj in
+            # LexicalParser.py), which is a different scheme entirely and
+            # can't be passed to tag_add() directly.
+            start_index = "{}.{}".format(token.line + 1, token.start)
+            end_index = "{}.{}".format(token.line + 1, token.start + token.size())
+            self.__thisTextArea.tag_add(tag, start_index, end_index)
 
     def __newFile(self):
         """Create a new file"""
@@ -213,8 +240,11 @@ class Notepad:
 
         # Reset the interpreter's global state before each run, so a
         # previous Execute click's variables/classes/functions don't leak
-        # into this one.
+        # into this one. reset() rebuilds SymbolTable via __init__, which
+        # sets input_handler back to None - so it has to be (re)assigned
+        # after reset(), not before.
         symbolTable.reset()
+        symbolTable.input_handler = self.__askForInput
 
         # Perform lexical analysis (from_text=True - see __generateTags)
         lexer = LexicalParser(code, from_text=True).parse()
@@ -228,6 +258,21 @@ class Notepad:
 
         # Execute the parsed statements
         result = statements.execute()
+
+    def __askForInput(self, prompt):
+        """GUI counterpart of jaza's terminal input() fallback.
+
+        Wired in as symbolTable.input_handler (see __execute above) so a
+        script's 'jaza' statement pops up an actual dialog box in this
+        window instead of silently blocking on whatever terminal
+        Notepad.py happened to be launched from - which is easy to miss
+        entirely if the window doesn't obviously look "stuck".
+        """
+        result = askstring("Hamri - Input", prompt, parent=self.__root)
+        # A cancelled/closed dialog returns None - jaza still needs a
+        # string back (it decides for itself whether the text looks like
+        # a number), so treat that the same as an empty response.
+        return result if result is not None else ""
 
     def __clearEditor(self):
         """Clear all text out of the code editor"""

--- a/README.md
+++ b/README.md
@@ -146,9 +146,11 @@ kwisha
 
 ## Input: `jaza`
 
-`jaza` asks the user for input at the terminal and stores the result in
-a variable. Separate the prompt text and the variable name with a
-comma.
+`jaza` asks the user for input and stores the result in a variable.
+Separate the prompt text and the variable name with a comma. When run
+via `main.py` (console mode), the prompt appears as a normal terminal
+input; when run through the desktop Notepad IDE, it pops up a dialog
+box in the GUI itself instead.
 
 ```
 kwanza
@@ -160,11 +162,7 @@ kwisha
 > If the typed input is a plain whole number (e.g. `25`, or a negative
 > like `-3`), it's automatically stored as a number so it can be used
 > directly in comparisons and arithmetic. Anything else — including a
-> decimal like `3.5` — is stored as text. `jaza` always reads from the
-> terminal via a standard input prompt, even when running through the
-> desktop Notepad IDE — it doesn't currently pop up its own input
-> dialog there, so keep an eye on the terminal you launched
-> `Notepad.py` from if a script uses it.
+> decimal like `3.5` — is stored as text.
 
 ## Conditionals: `kama`
 
@@ -598,8 +596,6 @@ yet:
 | No inheritance or static/shared class variables | A `darasa` can't extend another class, and there's no way to share a variable across every instance of a class — only per-instance properties set via `nafsi`. |
 | No bare property declarations in a class body | A `darasa` block may only contain `eleza` method definitions — properties only come into existence once a method (typically the `jenga` constructor) assigns them with `nafsi.property = value`. |
 | No renaming or scoping on `leta` | An imported class/method always keeps its original name, and becomes available everywhere in the file once imported. |
-| `jaza` always reads from the terminal | Even when running a script through the desktop Notepad IDE, `jaza` prompts on the terminal `Notepad.py` was launched from, not in the GUI window itself. |
-| Notepad.py syntax highlighting | The desktop IDE's live syntax highlighting (`__generateTags`) is a pre-existing rough edge that doesn't currently color tokens correctly; script execution (Run/Execute) is unaffected. |
 
 ## Full example
 

--- a/StatementParser.py
+++ b/StatementParser.py
@@ -1232,7 +1232,11 @@ class InputStatement(Statement):
         
     def execute(self):
 
-        raw = input(str(self.value))
+        # symbolTable.read_input() falls back to a plain terminal input()
+        # prompt unless a host environment (e.g. the desktop Notepad) has
+        # set symbolTable.input_handler to something else, like a GUI
+        # dialog - see SymbolTable.read_input().
+        raw = symbolTable.read_input(str(self.value))
 
         # Auto-detect plain integers (e.g. from a numeric prompt like age)
         # so the result can be used with comparisons/arithmetic in 'kama'

--- a/SymbolTable.py
+++ b/SymbolTable.py
@@ -66,6 +66,16 @@ class SymbolTable:
         # resolve module names however makes sense there instead.
         self.module_loader = None
 
+        # Pluggable hook used by 'jaza' (input) to actually collect a
+        # value from whoever's running the script - a callable taking the
+        # prompt text and returning the typed string. Left as None, so a
+        # plain script (e.g. via main.py) falls back to a normal
+        # terminal input() prompt. A host with its own UI (e.g. the
+        # desktop Notepad) can override this to pop up a proper dialog
+        # instead of silently expecting input on whatever terminal
+        # happened to launch it.
+        self.input_handler = None
+
         # Set by 'rudisha' (return) so every enclosing block loop (kama,
         # wakati, huku) knows to stop running further statements and
         # unwind, all the way up to the function-call boundary - the one
@@ -103,6 +113,14 @@ class SymbolTable:
                 return f.read()
         except (IOError,OSError):
             return None
+
+    def read_input(self,prompt):
+        # Used by 'jaza' to actually collect a value - see input_handler
+        # above. Falls back to a plain terminal input() prompt so a
+        # script run from disk (main.py) behaves exactly as before.
+        if self.input_handler is not None:
+            return self.input_handler(prompt)
+        return input(prompt)
 
     def alias_function(self,new_name,original_name):
         # Backs 'leta's selective method import ('leta salamu kutoka Mtu

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ kwisha
 
 kwanza
 
-    hamri_v = "Hamri v1.02"
+    hamri_v = "Hamri v1.0.3"
 
     sayHi(hamri_v)
 


### PR DESCRIPTION
Follow-up to #<the feature/loops-classes-modules-leta PR number> — fixes the two
remaining known issues flagged in that PR's CHANGELOG entry, closing out v1.0.3.

## Fixes
- `jaza` now shows a proper dialog box when run through the desktop Notepad
  IDE, instead of silently blocking on whatever terminal launched it.
- Notepad.py's live syntax highlighting actually works now (was comparing
  against nonexistent token type names and using the wrong index format).
- Fixed a related lexer bug (string token length off by 2) surfaced while
  fixing the highlighting.

## Testing
Full regression suite re-run (classes, lists, loops, leta, aina, jaza) plus
a targeted test confirming the input-handler hook and token-span math are
both correct. All files compile cleanly.