### PR TITLE
Add light/dark background toggle for the Notepad editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Desktop IDE (`Notepad.py`)
+
+- **Added a light/dark background toggle for the code editor.** A new
+  "Dark Mode" toolbar button (mirrored by a new View menu, for the same
+  reason the Run/Clear buttons exist alongside the File menu - on macOS
+  this app's menu bar isn't always reliably reachable) switches the
+  editor between its original light background and a dark one. Syntax
+  highlighting colors switch with it - `Token.Identifier` was previously
+  hardcoded to plain black, which would have been invisible against a
+  dark background, so it (and every other token color) now comes from a
+  small per-theme color table instead. Scoped to the editor only - the
+  console pane already has its own fixed black background and isn't
+  affected.
+
 ## v1.0.3 — language feature expansion + interpreter fixes
 
 This is a large update that brings the interpreter up to date with an

--- a/Notepad.py
+++ b/Notepad.py
@@ -129,8 +129,8 @@ class Notepad:
         # on macOS this menu bar renders in the system menu bar, not the
         # window itself, and isn't always reliably reachable.
         self.__thisViewMenu = Menu(self.__thisMenuBar, tearoff=0)
-        self.__thisViewMenu.add_command(label="Light Editor Background", command=lambda: self.__applyEditorTheme(False))
-        self.__thisViewMenu.add_command(label="Dark Editor Background", command=lambda: self.__applyEditorTheme(True))
+        self.__thisViewMenu.add_command(label="Dark Mode", command=lambda: self.__applyEditorTheme(True))
+        self.__thisViewMenu.add_command(label="Light Mode", command=lambda: self.__applyEditorTheme(False))
         self.__thisMenuBar.add_cascade(label="View", menu=self.__thisViewMenu)
 
         # Create the Help menu

--- a/Notepad.py
+++ b/Notepad.py
@@ -59,6 +59,13 @@ class Notepad:
         self.__thisDefaultDir = '/home/bytefrost/Documents/Hamri/Projects/'
         self.__thisFile = None
         self.__Tokens = None
+        # Tracks which background the code editor (not the console, which
+        # already has its own fixed dark look) is currently showing, so
+        # toolbar button/View menu/syntax highlighting can all agree on
+        # which palette to use. Starts light - matches the editor's
+        # original unstyled (default Tk white) appearance, so existing
+        # behavior is unchanged until someone actually switches it.
+        self.__editorDarkMode = False
 
         self.__root.title(self.__thisTitle)
         self.__root.geometry(f"{self.__thisWidth}x{self.__thisHeight}")
@@ -86,6 +93,8 @@ class Notepad:
         self.__thisClearEditorButton.pack(side=LEFT, padx=4, pady=4)
         self.__thisClearConsoleButton = ttk.Button(self.__thisToolbar, text="Clear Console", command=self.__clearConsole)
         self.__thisClearConsoleButton.pack(side=LEFT, padx=4, pady=4)
+        self.__thisThemeButton = ttk.Button(self.__thisToolbar, text="Dark Mode", command=self.__toggleEditorTheme)
+        self.__thisThemeButton.pack(side=LEFT, padx=4, pady=4)
 
         # Create the console for displaying output
         self.__thisConsole = CustomText(self.__thisCodeFrame, font=("Courier", 12, "normal"), height=18, bg="black", fg="white")
@@ -114,6 +123,15 @@ class Notepad:
         self.__thisEditMenu.add_command(label="Copy", command=self.__copy)
         self.__thisEditMenu.add_command(label="Paste", command=self.__paste)
         self.__thisMenuBar.add_cascade(label="Edit", menu=self.__thisEditMenu)
+
+        # Create the View menu - also mirrored by the "Dark Mode" toolbar
+        # button above, for the same reason the Run/Clear buttons exist:
+        # on macOS this menu bar renders in the system menu bar, not the
+        # window itself, and isn't always reliably reachable.
+        self.__thisViewMenu = Menu(self.__thisMenuBar, tearoff=0)
+        self.__thisViewMenu.add_command(label="Light Editor Background", command=lambda: self.__applyEditorTheme(False))
+        self.__thisViewMenu.add_command(label="Dark Editor Background", command=lambda: self.__applyEditorTheme(True))
+        self.__thisMenuBar.add_cascade(label="View", menu=self.__thisViewMenu)
 
         # Create the Help menu
         self.__thisHelpMenu = Menu(self.__thisMenuBar, tearoff=0)
@@ -147,6 +165,26 @@ class Notepad:
         'string': 'Token.Literal',
     }
 
+    # Per-theme foreground colors for each highlight tag. Keyword/Operator/
+    # Literal (blue/green/purple) stay readable on both a white and a dark
+    # background as-is, but "Token.Identifier" was hardcoded to plain
+    # black - invisible against a dark editor background - so it's the one
+    # that actually needs to change between themes.
+    _TOKEN_COLORS = {
+        False: {  # light background
+            'Token.Keyword': 'blue',
+            'Token.Identifier': 'black',
+            'Token.Operator': 'green',
+            'Token.Literal': 'purple',
+        },
+        True: {  # dark background
+            'Token.Keyword': '#569cd6',
+            'Token.Identifier': '#f1f1f1',
+            'Token.Operator': '#6a9955',
+            'Token.Literal': '#c586c0',
+        },
+    }
+
     def __generateTags(self, event=None):
         """Generates tags for syntax highlighting"""
         # Remove previous highlighting (tag_remove clears the ranges but
@@ -155,10 +193,11 @@ class Notepad:
         for tag in ("Token.Keyword", "Token.Identifier", "Token.Operator", "Token.Literal"):
             self.__thisTextArea.tag_remove(tag, "1.0", "end")
 
-        self.__thisTextArea.tag_configure("Token.Keyword", foreground="blue", font=("Courier", 12, "bold"))
-        self.__thisTextArea.tag_configure("Token.Identifier", foreground="black", font=("Courier", 12, "normal"))
-        self.__thisTextArea.tag_configure("Token.Operator", foreground="green", font=("Courier", 12, "normal"))
-        self.__thisTextArea.tag_configure("Token.Literal", foreground="purple", font=("Courier", 12, "normal"))
+        colors = self._TOKEN_COLORS[self.__editorDarkMode]
+        self.__thisTextArea.tag_configure("Token.Keyword", foreground=colors['Token.Keyword'], font=("Courier", 12, "bold"))
+        self.__thisTextArea.tag_configure("Token.Identifier", foreground=colors['Token.Identifier'], font=("Courier", 12, "normal"))
+        self.__thisTextArea.tag_configure("Token.Operator", foreground=colors['Token.Operator'], font=("Courier", 12, "normal"))
+        self.__thisTextArea.tag_configure("Token.Literal", foreground=colors['Token.Literal'], font=("Courier", 12, "normal"))
 
         # Parse code and generate tokens. from_text=True is required here -
         # without it, LexicalParser treats its argument as a *file path* by
@@ -281,6 +320,29 @@ class Notepad:
     def __clearConsole(self):
         """Clear all output out of the console pane"""
         self.__thisConsole.delete("1.0", "end")
+
+    def __applyEditorTheme(self, dark):
+        """Switch the code editor's background between light and dark.
+
+        Scoped to the editor only - the console already has its own
+        fixed black/white look (see __init__) and isn't affected here.
+        """
+        self.__editorDarkMode = dark
+        if dark:
+            bg, fg, insertbg, selectbg = '#1e1e1e', '#f1f1f1', '#f1f1f1', '#3d5a73'
+        else:
+            bg, fg, insertbg, selectbg = '#ffffff', '#000000', '#000000', '#c3d9ff'
+        self.__thisTextArea.config(bg=bg, fg=fg, insertbackground=insertbg, selectbackground=selectbg)
+        self.__thisThemeButton.config(text="Light Mode" if dark else "Dark Mode")
+
+        # Re-apply syntax highlighting immediately with the new theme's
+        # colors (see _TOKEN_COLORS) rather than waiting for the next
+        # keystroke to trigger __generateTags via <<TextModified>>.
+        self.__generateTags()
+
+    def __toggleEditorTheme(self):
+        """Flip the editor background between light and dark."""
+        self.__applyEditorTheme(not self.__editorDarkMode)
 
     def __quitApplication(self):
         """Quit the application"""


### PR DESCRIPTION
## Summary
Adds a way to switch the desktop Notepad's code editor between a light
and dark background — a "Dark Mode" toolbar button, plus a matching
View menu for discoverability.

## Details
- Toolbar button toggles; View menu offers explicit "Light Mode" / "Dark Mode" commands for the same effect.
- Syntax highlighting now pulls its colors from a small per-theme table
  instead of hardcoded values - worth calling out that `Token.Identifier`
  was previously hardcoded to plain black, which would have been
  unreadable against a dark background if the toggle didn't account for
  it.
- Scoped to the editor only. The console pane already has a fixed black
  background and is untouched.

## Testing
`python3 -m py_compile Notepad.py` passes. Manually verified via code
review that theme state (`__editorDarkMode`) is threaded consistently
through the toolbar button, View menu, and `__generateTags`'s tag
coloring, and that toggling calls `__generateTags()` immediately so
highlighting doesn't wait for the next keystroke to recolor.