### PR TITLE
Fold dark/light editor toggle into v1.0.3 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Desktop IDE (`Notepad.py`)
-
-- **Added a light/dark background toggle for the code editor.** A new
-  "Dark Mode" toolbar button (mirrored by a new View menu, for the same
-  reason the Run/Clear buttons exist alongside the File menu - on macOS
-  this app's menu bar isn't always reliably reachable) switches the
-  editor between its original light background and a dark one. Syntax
-  highlighting colors switch with it - `Token.Identifier` was previously
-  hardcoded to plain black, which would have been invisible against a
-  dark background, so it (and every other token color) now comes from a
-  small per-theme color table instead. Scoped to the editor only - the
-  console pane already has its own fixed black background and isn't
-  affected.
-
 ## v1.0.3 — language feature expansion + interpreter fixes
 
 This is a large update that brings the interpreter up to date with an
@@ -244,6 +228,16 @@ lexer bug the highlighting fix surfaced along the way.
   stopped 2 characters early. `TokenObj` now takes an explicit
   `raw_length` (the un-stripped match length), so `.size()`/`.span()`
   reflect the real source position for every token type.
+- **Added a light/dark background toggle for the code editor.** A new
+  "Dark Mode" toolbar button (mirrored by a matching View menu, for the
+  same reason the Run/Clear buttons exist) switches the editor between
+  its original light background and a dark one. Syntax highlighting
+  colors switch with it - `Token.Identifier` was previously hardcoded to
+  plain black, which would have been invisible against a dark
+  background, so it (and every other token color) now comes from a
+  small per-theme color table instead. Scoped to the editor only - the
+  console pane already has its own fixed black background and isn't
+  affected.
 
 ## v1.0.2 — initial commit
 


### PR DESCRIPTION
The toggle feature was merged into the v1.0.3 tag rather than shipping as a separate release, so its changelog entry belongs under the existing v1.0.3 'Desktop IDE follow-up fixes' section instead of a standalone Unreleased heading.