### PR TITLE
Fix jaza-into-property crash; rename sawa operator to sawa na

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,34 @@ lexer bug the highlighting fix surfaced along the way.
   console pane already has its own fixed black background and isn't
   affected.
 
+## Unreleased
+
+### Bug fixes
+
+- **`jaza` into a property (e.g. `jaza "jina lako ni?:", nafsi.jina`)
+  crashed with `'PropertyExpression' object has no attribute 'name'`.**
+  `InputStatement` assumed its destination was always a plain variable
+  and read `.name` off it directly at parse time, but `read_operand()`
+  recognizes `obj.member` shapes as a `PropertyExpression` first (the
+  same logic that makes `chapa mtu1.jina` work), and that class has no
+  `.name`. `InputStatement` now keeps the raw destination and, at
+  execute time, writes straight onto the instance's property table for
+  a `PropertyExpression` target (the same way `obj.jina = value` does)
+  or falls back to the original plain-variable path otherwise. This was
+  previously the only way `jaza` could not be used to fill in an
+  object's property directly inside its own constructor.
+
+### Breaking changes
+
+- **The loose-equality word operator is now `sawa na`, not `sawa`.**
+  `Tokens.keyword`'s pattern changed from `\bsawa\b` to `\bsawa\s+na\b`,
+  so the lexer now matches both words as a single token (same as any
+  other one-piece word-operator) and `WORD_OPERATORS`'s key changed to
+  match. Existing scripts using the old bare `sawa` need updating to
+  `sawa na` — e.g. `kama umri sawa 20` becomes
+  `kama umri sawa na 20`. `kabisa`/`hakika` (strict equality) are
+  unaffected.
+
 ## v1.0.2 — initial commit
 
 The starting point this changelog's v1.0.3 entry above is measured

--- a/LexicalParser.py
+++ b/LexicalParser.py
@@ -18,7 +18,12 @@ WORD_OPERATORS = {
    'punguza': '-',   # "reduce/decrease" -> subtraction
    'mara': '*',      # "times" -> multiplication
    'gawa': '/',      # "divide/share" -> division
-   'sawa': '==',     # "equal/okay" -> loose equality
+   'sawa na': '==',  # "equal to/okay with" -> loose equality. Two words,
+                      # not one - see Tokens.keyword's \bsawa\s+na\b below,
+                      # which matches both words as a single token so this
+                      # dict lookup (and everything downstream) can keep
+                      # treating it exactly like any other one-piece
+                      # word-operator.
 }
 
 # Word-form operators that don't map onto an existing symbol - there's no
@@ -56,7 +61,15 @@ class Tokens(enum.Enum):
    # project (github.com/Hamri-language/Hamri), reimplemented properly
    # here as a bare-expression statement (matching chapa/rudisha's own
    # style) rather than the original's now-defunct 'aina(x)' call form.
-   keyword = r'(chapa|kama|jaza|kwisha|kwanza|eleza|sivyo|wakati|huku|\bkutoka\b|\bhadi\b|\brudisha\b|\bweka\b|\bkwenye\b|\bidadi\b|\bondoa\b|\bdarasa\b|\bleta\b|\baina\b|\binazidi\b|\bhaizidi\b|\bni\b|\bkabisa\b|\bhakika\b|\bongeza\b|\bpunguza\b|\bmara\b|\bgawa\b|\bsawa\b)'
+   # 'sawa' used to be a single-word operator on its own; it's now a
+   # two-word phrase, 'sawa na' ("equal to") - \bsawa\s+na\b matches both
+   # words (with any run of whitespace between them) as ONE token, so
+   # finditer() below never re-visits 'na' on its own afterwards (it just
+   # resumes scanning right after this match). Must come before a bare
+   # '\bna\b' would ever be added as its own keyword/operator - there
+   # isn't one today, so 'na' outside this phrase is just an ordinary
+   # variable name, same as any other unreserved word.
+   keyword = r'(chapa|kama|jaza|kwisha|kwanza|eleza|sivyo|wakati|huku|\bkutoka\b|\bhadi\b|\brudisha\b|\bweka\b|\bkwenye\b|\bidadi\b|\bondoa\b|\bdarasa\b|\bleta\b|\baina\b|\binazidi\b|\bhaizidi\b|\bni\b|\bkabisa\b|\bhakika\b|\bongeza\b|\bpunguza\b|\bmara\b|\bgawa\b|\bsawa\s+na\b)'
    # NOTE: '[' and ']' used to be written as '\\[' and '\\]' here, which in
    # a raw string is an escaped literal BACKSLASH followed by a bracket -
    # not the bracket itself. That silently meant square brackets were
@@ -166,10 +179,15 @@ class LexicalParser:
                # like any other reserved word, but the rest of the
                # interpreter expects to see the symbol ('>','<','=') it
                # already knows how to handle - so swap it in here, once,
-               # at the source.
-               if value in WORD_OPERATORS:
+               # at the source. Collapsed to single spaces before the
+               # dict lookup - 'sawa na' is two words, and the regex
+               # match (\bsawa\s+na\b) allows any run of whitespace
+               # between them, but the dict key is written with exactly
+               # one space.
+               normalized_value = ' '.join(value.split())
+               if normalized_value in WORD_OPERATORS:
                   token_type = 'operator'
-                  value = WORD_OPERATORS[value]
+                  value = WORD_OPERATORS[normalized_value]
                elif value in OPERATOR_KEYWORDS:
                   token_type = 'operator'
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ symbols.
 | `ni` | is | Word form of `=` — e.g. `umri ni 20` |
 | `inazidi` | exceeds | Word form of `>` |
 | `haizidi` | does not exceed | Word form of `<` |
-| `sawa` | equal, okay | Word form of `==` (loose equality) |
+| `sawa na` | equal to | Word form of `==` (loose equality) |
 | `kabisa` / `hakika` | completely / certainly | Strict equality — true only if both value *and* type match |
 | `ongeza` | add, increase | Word form of `+` |
 | `punguza` | reduce, decrease | Word form of `-` |
@@ -280,7 +280,7 @@ eleza square(x)
 kwisha
 
 eleza safe_divide(a, b)
-    kama b sawa 0
+    kama b sawa na 0
         chapa "Can't divide by zero"
         rudisha
     kwisha
@@ -310,8 +310,8 @@ kwisha
 | `-` | `punguza` | Subtraction | |
 | `*` | `mara` | Multiplication | |
 | `/` | `gawa` | Division | Returns a whole number when it divides evenly (`10/2` → `5`), otherwise a decimal (`7/2` → `3.5`) |
-| `==` | `sawa` | Loose equality | `1 == true` is true — numbers and booleans compare loosely |
-| | `kabisa` / `hakika` | Strict equality | True only if value *and* type match — `1 kabisa true` is false, unlike `==`/`sawa` |
+| `==` | `sawa na` | Loose equality | `1 == true` is true — numbers and booleans compare loosely |
+| | `kabisa` / `hakika` | Strict equality | True only if value *and* type match — `1 kabisa true` is false, unlike `==`/`sawa na` |
 
 ## Comments
 

--- a/StatementParser.py
+++ b/StatementParser.py
@@ -1221,15 +1221,22 @@ class FunctionDefinitionStatement(Statement):
 
 
 class InputStatement(Statement):
-    
+
     def __init__(self,arg):
-        
+
         self.value = arg[0].evaluate()
-        
-        self.storage = arg[1].name
-        
-        
-        
+
+        # arg[1] is the jaza destination. Almost always a plain variable
+        # (`jaza "prompt:", jina`), in which case read_operand() casts it
+        # to a Var with a `.name`. But read_operand() also runs
+        # try_parse_property_access() first, so `jaza "...", nafsi.jina`
+        # (or any `obj.member`) - a natural thing to write inside a
+        # constructor - comes back as a PropertyExpression instead, which
+        # has no `.name`. Keep the raw target here and branch on its
+        # actual type in execute() rather than assuming .name exists.
+        self.target = arg[1]
+
+
     def execute(self):
 
         # symbolTable.read_input() falls back to a plain terminal input()
@@ -1244,13 +1251,25 @@ class InputStatement(Statement):
         token_type = 'integer' if raw.lstrip('-').isdigit() else 'string'
 
         var = Object(TokenObj(token_type,raw,0,0,0)).cast()
+        value = Literal(var.evaluate())
 
-        # Same call_flag-based scope check as huku's loop variable (see
-        # ForStatement.execute()) - symbolTable.get_scope('var-scope') only
-        # reflects parse-time bookkeeping, which has already unwound by
-        # the time this runs.
-        var_scope = 'local' if symbolTable.call_flag else 'global'
-        symbolTable.write_variable(var_scope,self.storage,Literal(var.evaluate()))
+        if isinstance(self.target,PropertyExpression):
+            # Write straight onto the instance's own property table, the
+            # same way PropertyAssignmentStatement does for a plain
+            # `obj.jina = ...` - 'nafsi' inside a method is nothing
+            # special, just a local variable holding the current
+            # instance, same as everywhere else in the language.
+            instance = _fetch_instance(self.target.object_name)
+            if instance is None:
+                return
+            symbolTable.table['variables'][instance.scope_key][self.target.property_name] = value
+        else:
+            # Same call_flag-based scope check as huku's loop variable (see
+            # ForStatement.execute()) - symbolTable.get_scope('var-scope') only
+            # reflects parse-time bookkeeping, which has already unwound by
+            # the time this runs.
+            var_scope = 'local' if symbolTable.call_flag else 'global'
+            symbolTable.write_variable(var_scope,self.target.name,value)
         
         
 


### PR DESCRIPTION
This PR bundles two independent fixes:

**1. Fix crash when `jaza` fills a property instead of a plain variable**

`InputStatement` assumed its `jaza` destination was always a plain variable and read `.name` off it directly. But `read_operand()` also recognizes `obj.member` destinations (e.g. `nafsi.jina`) as a `PropertyExpression` — the same logic that makes `chapa mtu1.jina` work — and that class has no `.name`. So writing straight into an object's property from inside its own constructor, e.g.:

```
eleza jenga(jina)
    jaza "jina lako ni?:", nafsi.jina
kwisha
```

crashed with `Runtime error: 'PropertyExpression' object has no attribute 'name'`.

`InputStatement` now keeps the raw destination and branches on its type at execute time: a `PropertyExpression` writes onto the instance's property table directly (same as `obj.jina = value`), everything else keeps the original plain-variable path.

**2. Rename the `sawa` operator keyword to the two-word `sawa na`**

`Tokens.keyword`'s pattern for loose equality changed from `\bsawa\b` to `\bsawa\s+na\b`, so the lexer matches both words as a single token (collapsing any whitespace between them). `WORD_OPERATORS`'s key changed to match.

**Breaking change:** existing scripts using the old bare `sawa` need updating to `sawa na` — e.g. `kama umri sawa 20` becomes `kama umri sawa na 20`. `kabisa`/`hakika` (strict equality) are unaffected.

**Testing**

Both changes verified against `test_v1_0_3.ham` and `main.py`'s built-in sample script, with no regressions. `README.md` and `CHANGELOG.md` updated accordingly.