### PR TITLE
Add a real inline conditional expression (kama ... sivyo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,20 @@
 
 ## Unreleased
 
-### Desktop IDE (`Notepad.py`)
+### New language features
 
-- **Added a light/dark background toggle for the code editor.** A new
-  "Dark Mode" toolbar button (mirrored by a new View menu, for the same
-  reason the Run/Clear buttons exist alongside the File menu - on macOS
-  this app's menu bar isn't always reliably reachable) switches the
-  editor between its original light background and a dark one. Syntax
-  highlighting colors switch with it - `Token.Identifier` was previously
-  hardcoded to plain black, which would have been invisible against a
-  dark background, so it (and every other token color) now comes from a
-  small per-theme color table instead. Scoped to the editor only - the
-  console pane already has its own fixed black background and isn't
-  affected.
+- **Inline conditionals: `<value> kama <condition> sivyo <value>`.**
+  The same `kama`/`sivyo` words used for an if-block now also work
+  inline, as a real conditional expression (like Python's
+  `x if cond else y`) usable anywhere a value is expected - an
+  assignment, a `chapa`, a function argument, and so on, e.g.
+  `hali = "mtu mzima" kama umri inazidi 17 sivyo "kijana"`. Only the
+  branch actually taken is ever evaluated. `sivyo` is required; writing
+  `kama` without a matching `sivyo` right after it falls back to
+  starting an ordinary `kama` block instead, exactly as before - so
+  existing scripts that happen to have a bare `kama` following an
+  expression on the same line are unaffected. Chains left to right for
+  an else-if ladder: `"A" kama x sivyo "B" kama y sivyo "C"`.
 
 ## v1.0.3 — language feature expansion + interpreter fixes
 
@@ -244,6 +245,16 @@ lexer bug the highlighting fix surfaced along the way.
   stopped 2 characters early. `TokenObj` now takes an explicit
   `raw_length` (the un-stripped match length), so `.size()`/`.span()`
   reflect the real source position for every token type.
+- **Added a light/dark background toggle for the code editor.** A new
+  "Dark Mode" toolbar button (mirrored by a matching View menu, for the
+  same reason the Run/Clear buttons exist) switches the editor between
+  its original light background and a dark one. Syntax highlighting
+  colors switch with it - `Token.Identifier` was previously hardcoded to
+  plain black, which would have been invisible against a dark
+  background, so it (and every other token color) now comes from a
+  small per-theme color table instead. Scoped to the editor only - the
+  console pane already has its own fixed black background and isn't
+  affected.
 
 ## v1.0.2 — initial commit
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,40 @@ kwisha
 `kama` blocks can be nested inside functions, inside loops, and inside
 each other.
 
+## Inline conditionals: `kama ... sivyo`
+
+The same `kama`/`sivyo` words also work inline, as a value rather than
+a whole block — pick one of two values based on a condition, right
+inside an assignment, a `chapa`, or anywhere else a value is expected.
+It reads left to right: `<value if true> kama <condition> sivyo <value
+if false>`.
+
+```
+kwanza
+    umri = 20
+    hali = "mtu mzima" kama umri inazidi 17 sivyo "kijana"
+    chapa hali
+kwisha
+```
+
+Only the branch actually picked is ever evaluated, so it's safe to
+reach for something that would otherwise error out (like an unset
+property) on the branch that never runs. `sivyo` is required — unlike
+the block form, there's no "no-op if false" version of this. Chain
+several together for an else-if ladder:
+
+```
+kwanza
+    alama = 72
+    daraja = "A" kama alama inazidi 89 sivyo "B" kama alama inazidi 79 sivyo "C"
+    chapa daraja
+kwisha
+```
+
+> Writing `kama` without a matching `sivyo` right after it isn't
+> treated as an inline conditional at all — it falls back to starting
+> a brand new `kama` block instead, same as if it were on its own line.
+
 ## Loops: `wakati`
 
 `wakati` ("while") repeats its block for as long as the condition stays

--- a/StatementParser.py
+++ b/StatementParser.py
@@ -485,8 +485,46 @@ class StatementParser:
         # the expression.
         special = self.try_parse_special_value()
         if special is not None:
-            return ExpressionParser(self.continue_express(special)).parse()
-        return ExpressionParser(self.fetch_express()).parse()
+            value = ExpressionParser(self.continue_express(special)).parse()
+        else:
+            value = ExpressionParser(self.fetch_express()).parse()
+        return self.try_parse_ternary(value)
+
+    def try_parse_ternary(self,true_value):
+        # Detects a trailing '<true_value> kama <condition> sivyo
+        # <false_value>' ternary suffix right after an already-parsed
+        # value - a real inline conditional expression (like Python's
+        # 'x if cond else y'), e.g.
+        # `jina kama jina sawa na "Cookie" sivyo "Guest"`. 'kama' is a
+        # keyword, not an operator, so fetch_express()'s own
+        # operand-reading loop already stops cleanly right before it -
+        # this picks up exactly where that left off.
+        #
+        # Requires 'sivyo' - if it's missing (a malformed/incomplete
+        # ternary), token_position is rewound to right where it was
+        # before this method ever looked at 'kama', so the caller falls
+        # back to treating 'kama' as the start of a brand new statement
+        # (an ordinary if-block) exactly as it always has, rather than
+        # this method guessing at what a half-written ternary meant.
+        if self.next_token() is None or self.next_token().value != 'kama':
+            return true_value
+
+        rollback_position = self.token_position
+        self.token_position = self.token_position + 1  # land on 'kama'
+        condition = ExpressionParser(self.fetch_express()).parse()
+
+        if self.next_token() is None or self.next_token().value != 'sivyo':
+            self.token_position = rollback_position
+            return true_value
+
+        self.token_position = self.token_position + 1  # land on 'sivyo'
+        # Recursing (rather than a single fetch_express()) lets the
+        # false-branch itself be another ternary, so
+        # 'a kama x sivyo b kama y sivyo c' chains like an else-if
+        # ladder, evaluated left to right.
+        false_value = self.parse_expression_value()
+
+        return ConditionalExpression(true_value,condition,false_value)
 
     def continue_express(self,first):
         # Same operator-chaining loop as fetch_express()'s own while-loop,
@@ -1017,6 +1055,31 @@ def _fetch_instance(name):
         Error.throwException('darasa',name)
         return None
     return value
+
+
+class ConditionalExpression(Object):
+    # `<true_value> kama <condition> sivyo <false_value>` used as a
+    # value - a real inline conditional expression (Python's ternary,
+    # `x if cond else y`), e.g.
+    # `nafsi.jina = jina kama jina sawa na "Cookie" sivyo "Guest"`.
+    # Built by try_parse_ternary() (see parse_expression_value()) - not
+    # tied to any ExpressionParser operator symbol, since it isn't a
+    # binary operator at all, just two branches and a condition.
+    #
+    # Evaluated lazily: only the branch actually taken is ever
+    # evaluated, exactly like the kama/sivyo *statement* form already
+    # behaves - so a false_value that would itself error out (e.g.
+    # reading a property that's only set on the true branch) is never
+    # touched unless the condition actually picks it.
+    def __init__(self,true_value,condition,false_value):
+        self.true_value = true_value
+        self.condition = condition
+        self.false_value = false_value
+
+    def evaluate(self):
+        if self.condition.evaluate():
+            return self.true_value.evaluate()
+        return self.false_value.evaluate()
 
 
 class PropertyExpression(Object):


### PR DESCRIPTION
parse_expression_value() now checks for a trailing '<true_value> kama <condition> sivyo <false_value>' suffix after any value it parses - a real ternary (Python's 'x if cond else y'), usable anywhere a value is expected: assignments, chapa, function arguments, etc.

'kama' is a keyword, not an operator, so fetch_express()'s own operand-reading loop already stopped cleanly right before it - this adds a new try_parse_ternary() step that picks up from there instead of leaving 'kama ...' to be silently misparsed as a new, unrelated if-block (which is what happened before this change).

sivyo is required; if it's missing, token_position rewinds and 'kama' falls back to starting an ordinary if-block, unchanged from today - so this is purely additive, no existing script's behavior changes. Chains recursively for an else-if ladder.

Verified against test_v1_0_3.ham and main.py's built-in sample with no regressions, plus new coverage: matching/non-matching conditions, chained ternaries, and the missing-sivyo fallback.