### PR TITLE
Quote the source line number in every runtime error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,20 @@
 
 ## Unreleased
 
-### Desktop IDE (`Notepad.py`)
+### New language features
 
-- **Added a light/dark background toggle for the code editor.** A new
-  "Dark Mode" toolbar button (mirrored by a new View menu, for the same
-  reason the Run/Clear buttons exist alongside the File menu - on macOS
-  this app's menu bar isn't always reliably reachable) switches the
-  editor between its original light background and a dark one. Syntax
-  highlighting colors switch with it - `Token.Identifier` was previously
-  hardcoded to plain black, which would have been invisible against a
-  dark background, so it (and every other token color) now comes from a
-  small per-theme color table instead. Scoped to the editor only - the
-  console pane already has its own fixed black background and isn't
-  affected.
+- **Inline conditionals: `<value> kama <condition> sivyo <value>`.**
+  The same `kama`/`sivyo` words used for an if-block now also work
+  inline, as a real conditional expression (like Python's
+  `x if cond else y`) usable anywhere a value is expected - an
+  assignment, a `chapa`, a function argument, and so on, e.g.
+  `hali = "mtu mzima" kama umri inazidi 17 sivyo "kijana"`. Only the
+  branch actually taken is ever evaluated. `sivyo` is required; writing
+  `kama` without a matching `sivyo` right after it falls back to
+  starting an ordinary `kama` block instead, exactly as before - so
+  existing scripts that happen to have a bare `kama` following an
+  expression on the same line are unaffected. Chains left to right for
+  an else-if ladder: `"A" kama x sivyo "B" kama y sivyo "C"`.
 
 ## v1.0.3 — language feature expansion + interpreter fixes
 
@@ -244,6 +245,16 @@ lexer bug the highlighting fix surfaced along the way.
   stopped 2 characters early. `TokenObj` now takes an explicit
   `raw_length` (the un-stripped match length), so `.size()`/`.span()`
   reflect the real source position for every token type.
+- **Added a light/dark background toggle for the code editor.** A new
+  "Dark Mode" toolbar button (mirrored by a matching View menu, for the
+  same reason the Run/Clear buttons exist) switches the editor between
+  its original light background and a dark one. Syntax highlighting
+  colors switch with it - `Token.Identifier` was previously hardcoded to
+  plain black, which would have been invisible against a dark
+  background, so it (and every other token color) now comes from a
+  small per-theme color table instead. Scoped to the editor only - the
+  console pane already has its own fixed black background and isn't
+  affected.
 
 ## v1.0.2 — initial commit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@
   expression on the same line are unaffected. Chains left to right for
   an else-if ladder: `"A" kama x sivyo "B" kama y sivyo "C"`.
 
+### Improvements
+
+- **Runtime errors now quote the source line they happened on** -
+  every message is prefixed with `Mstari <n>:`. Previously a statement
+  object never carried forward the line number of the token it started
+  on, so an error deep in a long script gave no clue where to look.
+  `StatementParser.parse()`'s single dispatch loop now stamps every
+  parsed statement with `.line` (the 1-indexed line its first token
+  came from - `TokenObj.line`, from `LexicalParser`, is 0-indexed);
+  every statement-list execution loop (`kwanza`'s own, and every
+  `kama`/`wakati`/`huku`/function-call body) sets
+  `symbolTable.current_line` from it right before that statement
+  actually runs. `Errors._report()` reads that value and prefixes it
+  onto every message, so any error raised while a statement is
+  executing - including one that bubbles up from deep inside a nested
+  expression - is automatically attributed to the right line, with no
+  per-expression-node plumbing needed. Two exceptions handled
+  explicitly: `leta` (`Kosa La Leta`) fails at parse time, before
+  `current_line` would even reflect it, so its own line is passed
+  through directly instead; and a runaway loop (`Kosa La Mzunguko`)
+  quotes the loop's own header line rather than whatever body statement
+  happened to be running when the 100,000-iteration cap hit, since the
+  loop itself is what's actually wrong.
+
 ## v1.0.3 — language feature expansion + interpreter fixes
 
 This is a large update that brings the interpreter up to date with an

--- a/Errors.py
+++ b/Errors.py
@@ -1,14 +1,28 @@
 from SymbolTable import symbolTable
 
-def _report(message):
+def _report(message,line=None):
     # Route error text through whatever console the current run is using
     # (Tk Text widget, the web IDE's console shim, ...) so it's actually
     # visible there, same as chapa output. Falls back to print() for the
     # plain CLI (main.py), which never sets a console.
+    #
+    # Prefixes the source line whenever one's available - either passed
+    # explicitly (see Errors.throwException's 'line' argument, used for
+    # 'leta', which fails at parse time rather than execute time) or,
+    # for every other error, symbolTable.current_line - kept up to date
+    # by every statement-list execution loop (StatementParser.parse()'s
+    # own, and every kama/wakati/huku/function-call body) right before
+    # each statement actually runs. Falls back to no prefix at all only
+    # if neither is set (e.g. an error somehow raised before any
+    # statement has started executing).
+    resolved_line = line if line is not None else symbolTable.current_line
+    prefix = 'Mstari {}: '.format(resolved_line) if resolved_line is not None else ''
+    full_message = '{}{}'.format(prefix,message)
+
     if symbolTable.console is not None:
-        symbolTable.console.insert('end','{}\n'.format(message))
+        symbolTable.console.insert('end','{}\n'.format(full_message))
     else:
-        print(message)
+        print(full_message)
 
 class Errors:
     def __init__(self):
@@ -25,28 +39,30 @@ class Errors:
 
         }
 
-    def throwException(self,arg,args=''):
+    def throwException(self,arg,args='',line=None):
 
-        self.exceptions[arg](args).execute()
+        self.exceptions[arg](args,line).execute()
 
 class VariableReferenceException:
 
-    def __init__(self,arg):
+    def __init__(self,arg,line=None):
         self.name = arg
+        self.line = line
 
     def execute(self):
-        _report('Kosa La Anwani: Jina hili {' +self.name +'} halijulikani')
+        _report('Kosa La Anwani: Jina hili {' +self.name +'} halijulikani',self.line)
         symbolTable.exit(1)
 
 
 class FunctionReferenceException:
     # 'kazi' = Swahili for "job/task" - used here for "function".
 
-    def __init__(self,arg):
+    def __init__(self,arg,line=None):
         self.name = arg
+        self.line = line
 
     def execute(self):
-        _report('Kosa La Kazi: Kazi hii {' +self.name +'} haijaelezwa (undefined function)')
+        _report('Kosa La Kazi: Kazi hii {' +self.name +'} haijaelezwa (undefined function)',self.line)
         symbolTable.exit(1)
 
 
@@ -55,11 +71,12 @@ class LoopLimitException:
     # became false ran too many iterations and was stopped, rather than
     # freezing the page forever.
 
-    def __init__(self,arg):
+    def __init__(self,arg,line=None):
         self.name = arg
+        self.line = line
 
     def execute(self):
-        _report('Kosa La Mzunguko: mzunguko {} haujaisha (loop did not end - check your condition)'.format(self.name))
+        _report('Kosa La Mzunguko: mzunguko {} haujaisha (loop did not end - check your condition)'.format(self.name),self.line)
         symbolTable.exit(1)
 
 
@@ -67,11 +84,12 @@ class IndexOutOfRangeException:
     # 'fahirisi' = Swahili for "index" - reading or writing a list
     # position that doesn't exist (negative, or past the end).
 
-    def __init__(self,arg):
+    def __init__(self,arg,line=None):
         self.name = arg
+        self.line = line
 
     def execute(self):
-        _report('Kosa La Fahirisi: fahirisi hii katika {' +self.name +'} haipo (index out of range)')
+        _report('Kosa La Fahirisi: fahirisi hii katika {' +self.name +'} haipo (index out of range)',self.line)
         symbolTable.exit(1)
 
 
@@ -79,11 +97,12 @@ class NotAListException:
     # 'orodha' = Swahili for "list" - trying to index/append/loop over a
     # variable that isn't actually holding a list.
 
-    def __init__(self,arg):
+    def __init__(self,arg,line=None):
         self.name = arg
+        self.line = line
 
     def execute(self):
-        _report('Kosa La Orodha: {' +self.name +'} si orodha (not a list)')
+        _report('Kosa La Orodha: {' +self.name +'} si orodha (not a list)',self.line)
         symbolTable.exit(1)
 
 
@@ -92,11 +111,12 @@ class NotAnObjectException:
     # call a method on a variable that isn't actually holding an object
     # (an instance of some darasa).
 
-    def __init__(self,arg):
+    def __init__(self,arg,line=None):
         self.name = arg
+        self.line = line
 
     def execute(self):
-        _report('Kosa La Darasa: {' +self.name +'} si kitu (not an object)')
+        _report('Kosa La Darasa: {' +self.name +'} si kitu (not an object)',self.line)
         symbolTable.exit(1)
 
 
@@ -106,12 +126,19 @@ class ImportException:
     # message: the file itself couldn't be found/read, the requested class
     # isn't defined in it, or (for a selective method import) the
     # requested method isn't defined on that class.
+    #
+    # Unlike every other exception here, this one fires at *parse* time
+    # (leta has no runtime behaviour of its own - see StatementParser's
+    # 'leta' case) rather than execute time, so symbolTable.current_line
+    # wouldn't reflect it. StatementParser passes the leta statement's
+    # own line explicitly instead - see throwException's 'line' argument.
 
-    def __init__(self,arg):
+    def __init__(self,arg,line=None):
         self.name = arg
+        self.line = line
 
     def execute(self):
-        _report('Kosa La Leta: {' +self.name +'} haipatikani (import failed - check the file name, class name, or method name)')
+        _report('Kosa La Leta: {' +self.name +'} haipatikani (import failed - check the file name, class name, or method name)',self.line)
         symbolTable.exit(1)
 
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,40 @@ kwisha
 `kama` blocks can be nested inside functions, inside loops, and inside
 each other.
 
+## Inline conditionals: `kama ... sivyo`
+
+The same `kama`/`sivyo` words also work inline, as a value rather than
+a whole block — pick one of two values based on a condition, right
+inside an assignment, a `chapa`, or anywhere else a value is expected.
+It reads left to right: `<value if true> kama <condition> sivyo <value
+if false>`.
+
+```
+kwanza
+    umri = 20
+    hali = "mtu mzima" kama umri inazidi 17 sivyo "kijana"
+    chapa hali
+kwisha
+```
+
+Only the branch actually picked is ever evaluated, so it's safe to
+reach for something that would otherwise error out (like an unset
+property) on the branch that never runs. `sivyo` is required — unlike
+the block form, there's no "no-op if false" version of this. Chain
+several together for an else-if ladder:
+
+```
+kwanza
+    alama = 72
+    daraja = "A" kama alama inazidi 89 sivyo "B" kama alama inazidi 79 sivyo "C"
+    chapa daraja
+kwisha
+```
+
+> Writing `kama` without a matching `sivyo` right after it isn't
+> treated as an inline conditional at all — it falls back to starting
+> a brand new `kama` block instead, same as if it were on its own line.
+
 ## Loops: `wakati`
 
 `wakati` ("while") repeats its block for as long as the condition stays

--- a/README.md
+++ b/README.md
@@ -602,7 +602,28 @@ kwisha
 ## Error messages
 
 Hamri reports runtime errors in Swahili and stops the script (exit code
-1) rather than continuing silently.
+1) rather than continuing silently. Every message is prefixed with
+`Mstari <n>:` ("Line n") — the source line the failing statement
+started on — so you don't have to guess which part of a long script
+actually went wrong:
+
+```
+Mstari 4: Kosa La Anwani: Jina hili {umri} halijulikani
+```
+
+The quoted line is always the *statement* that was running when the
+error happened — the `chapa`/`kama`/`wakati`/function-call line itself,
+not some internal detail of how the expression inside it was built.
+That's true even when the failure comes from deep inside a nested
+expression (e.g. an undefined property read as part of a larger
+`chapa`), from inside a loop or function body, or from a `leta` import
+that couldn't find its file (reported at parse time, before the script
+even starts running, since `leta` has no runtime step of its own). A
+runaway `wakati`/`huku` loop (`Kosa La Mzunguko`) is the one exception
+worth calling out — it quotes the loop's own header line, not whatever
+body statement happened to be running on the iteration that tripped
+the 100,000-iteration cap, since the loop itself (not that particular
+statement) is what's actually wrong.
 
 | Message | Cause |
 |---|---|

--- a/StatementParser.py
+++ b/StatementParser.py
@@ -287,17 +287,24 @@ class StatementParser:
             self.token_position = self.token_position + 1  # land on 'kutoka'
             after_kutoka = self.next_token()
 
+            # leta has no runtime behaviour of its own (see _parse_module),
+            # so a failed import is reported right here, at parse time -
+            # symbolTable.current_line (updated only as statements
+            # *execute*) wouldn't reflect this line, so it's passed
+            # through explicitly instead.
+            leta_line = parse_token.line + 1
+
             if after_kutoka is not None and after_kutoka.token_type == 'string':
                 self.token_position = self.token_position + 1  # land on the filename string
                 filename = self.tokens[self.token_position].value
-                self.import_classes(names,filename)
+                self.import_classes(names,filename,leta_line)
             else:
                 class_name = after_kutoka.value if after_kutoka is not None else None
                 self.token_position = self.token_position + 1  # land on <class-name>
                 self.token_position = self.token_position + 1  # land on 'kutoka'
                 self.token_position = self.token_position + 1  # land on the filename string
                 filename = self.tokens[self.token_position].value
-                self.import_methods(names,class_name,filename)
+                self.import_methods(names,class_name,filename,leta_line)
 
         elif parse_token.value == 'kwanza':
             Log('case for main block')
@@ -437,26 +444,26 @@ class StatementParser:
 
         return True
 
-    def import_classes(self,names,filename):
+    def import_classes(self,names,filename,line=None):
         # 'leta A, B kutoka "faili"' - pulls in one or more whole classes.
         if not self._parse_module(filename):
-            Error.throwException('leta',filename)
+            Error.throwException('leta',filename,line)
             return
         for name in names:
             if name not in symbolTable.table['classes']:
-                Error.throwException('leta','{} ({})'.format(name,filename))
+                Error.throwException('leta','{} ({})'.format(name,filename),line)
 
-    def import_methods(self,names,class_name,filename):
+    def import_methods(self,names,class_name,filename,line=None):
         # 'leta a, b kutoka ClassName kutoka "faili"' - pulls in one or
         # more specific methods of a class, callable standalone (see
         # SymbolTable.alias_function).
         if not self._parse_module(filename):
-            Error.throwException('leta',filename)
+            Error.throwException('leta',filename,line)
             return
         for name in names:
             qualified_name = 'darasa-{}-{}'.format(class_name,name)
             if not symbolTable.alias_function(name,qualified_name):
-                Error.throwException('leta','{}.{} ({})'.format(class_name,name,filename))
+                Error.throwException('leta','{}.{} ({})'.format(class_name,name,filename),line)
 
     def try_parse_special_value(self):
         # Tries each of the "not a plain fetch_express() expression"
@@ -755,11 +762,23 @@ class StatementParser:
         Log('=======================')        
         
         while self.token_position < len(self.tokens):
-            
+
+            # Captured *before* parseStatement() runs, since parsing a
+            # statement advances self.token_position to wherever it
+            # finished (its last consumed token) - only the token it
+            # started on tells us the line the statement actually began
+            # on. TokenObj.line is 0-indexed (see LexicalParser); +1
+            # here so every line number that ever reaches the user
+            # (error messages) matches what they'd count in an editor.
+            start_line = self.tokens[self.token_position].line + 1
+
             statement = self.parseStatement(self.tokens[self.token_position])
-            
+
+            if statement is not None:
+                statement.line = start_line
+
             #print('Function definition flag:',symbolTable.def_flag)
- 
+
             Log(statement,'Evaluated statement')
             Log(symbolTable.get_scope('function-scope'),'Current context')
             
@@ -848,6 +867,7 @@ class StatementParser:
             if symbolTable.exit() == 0 and not symbolTable.is_returning():
                 Log('kwanza','Executing from scope')
                 Log(i,'Executing statement')
+                symbolTable.current_line = i.line
                 i.execute()
 
             else:
@@ -975,6 +995,7 @@ class FunctionCallStatement(Statement):
 
             Log(i,'Executing statement')
 
+            symbolTable.current_line = i.line
             i.execute()
 
         # This is the function-call boundary: absorb the return flag here
@@ -1284,15 +1305,22 @@ class FunctionDefinitionStatement(Statement):
 
 
 class InputStatement(Statement):
-    
+
     def __init__(self,arg):
-        
+
         self.value = arg[0].evaluate()
-        
-        self.storage = arg[1].name
-        
-        
-        
+
+        # arg[1] is the jaza destination. Almost always a plain variable
+        # (`jaza "prompt:", jina`), in which case read_operand() casts it
+        # to a Var with a `.name`. But read_operand() also runs
+        # try_parse_property_access() first, so `jaza "...", nafsi.jina`
+        # (or any `obj.member`) - a natural thing to write inside a
+        # constructor - comes back as a PropertyExpression instead, which
+        # has no `.name`. Keep the raw target here and branch on its
+        # actual type in execute() rather than assuming .name exists.
+        self.target = arg[1]
+
+
     def execute(self):
 
         # symbolTable.read_input() falls back to a plain terminal input()
@@ -1307,13 +1335,25 @@ class InputStatement(Statement):
         token_type = 'integer' if raw.lstrip('-').isdigit() else 'string'
 
         var = Object(TokenObj(token_type,raw,0,0,0)).cast()
+        value = Literal(var.evaluate())
 
-        # Same call_flag-based scope check as huku's loop variable (see
-        # ForStatement.execute()) - symbolTable.get_scope('var-scope') only
-        # reflects parse-time bookkeeping, which has already unwound by
-        # the time this runs.
-        var_scope = 'local' if symbolTable.call_flag else 'global'
-        symbolTable.write_variable(var_scope,self.storage,Literal(var.evaluate()))
+        if isinstance(self.target,PropertyExpression):
+            # Write straight onto the instance's own property table, the
+            # same way PropertyAssignmentStatement does for a plain
+            # `obj.jina = ...` - 'nafsi' inside a method is nothing
+            # special, just a local variable holding the current
+            # instance, same as everywhere else in the language.
+            instance = _fetch_instance(self.target.object_name)
+            if instance is None:
+                return
+            symbolTable.table['variables'][instance.scope_key][self.target.property_name] = value
+        else:
+            # Same call_flag-based scope check as huku's loop variable (see
+            # ForStatement.execute()) - symbolTable.get_scope('var-scope') only
+            # reflects parse-time bookkeeping, which has already unwound by
+            # the time this runs.
+            var_scope = 'local' if symbolTable.call_flag else 'global'
+            symbolTable.write_variable(var_scope,self.target.name,value)
         
         
 
@@ -1333,12 +1373,14 @@ class IfStatement(Statement):
             for i in symbolTable.table['functions'][self.true_name]:
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
+                symbolTable.current_line = i.line
                 i.execute()
         elif self.else_name is not None:
             Log('condition false, executing sivyo-block {}'.format(self.else_name),'If Execution')
             for i in symbolTable.table['functions'][self.else_name]:
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
+                symbolTable.current_line = i.line
                 i.execute()
         else:
             Log('condition false, no sivyo branch, skipping','If Execution')
@@ -1362,11 +1404,16 @@ class WhileStatement(Statement):
                 break
             iterations = iterations + 1
             if iterations > self.MAX_ITERATIONS:
-                Error.throwException('mzunguko',self.name)
+                # self.line (not symbolTable.current_line, which by now
+                # would just hold whatever body statement last ran) -
+                # the loop's own header line is more useful here than
+                # wherever execution happened to be when it gave up.
+                Error.throwException('mzunguko',self.name,self.line)
                 break
             for i in symbolTable.table['functions'][self.name]:
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
+                symbolTable.current_line = i.line
                 i.execute()
             if symbolTable.is_returning():
                 break
@@ -1409,7 +1456,11 @@ class ForStatement(Statement):
                 break
             iterations = iterations + 1
             if iterations > self.MAX_ITERATIONS:
-                Error.throwException('mzunguko',self.name)
+                # self.line (not symbolTable.current_line, which by now
+                # would just hold whatever body statement last ran) -
+                # the loop's own header line is more useful here than
+                # wherever execution happened to be when it gave up.
+                Error.throwException('mzunguko',self.name,self.line)
                 break
 
             # Same storage path as a normal assignment (Var mode 1) -
@@ -1424,6 +1475,7 @@ class ForStatement(Statement):
             for i in symbolTable.table['functions'][self.name]:
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
+                symbolTable.current_line = i.line
                 i.execute()
 
             if symbolTable.is_returning():
@@ -1462,6 +1514,7 @@ class ForEachStatement(Statement):
             for i in symbolTable.table['functions'][self.name]:
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
+                symbolTable.current_line = i.line
                 i.execute()
 
             if symbolTable.is_returning():

--- a/StatementParser.py
+++ b/StatementParser.py
@@ -485,8 +485,46 @@ class StatementParser:
         # the expression.
         special = self.try_parse_special_value()
         if special is not None:
-            return ExpressionParser(self.continue_express(special)).parse()
-        return ExpressionParser(self.fetch_express()).parse()
+            value = ExpressionParser(self.continue_express(special)).parse()
+        else:
+            value = ExpressionParser(self.fetch_express()).parse()
+        return self.try_parse_ternary(value)
+
+    def try_parse_ternary(self,true_value):
+        # Detects a trailing '<true_value> kama <condition> sivyo
+        # <false_value>' ternary suffix right after an already-parsed
+        # value - a real inline conditional expression (like Python's
+        # 'x if cond else y'), e.g.
+        # `jina kama jina sawa na "Cookie" sivyo "Guest"`. 'kama' is a
+        # keyword, not an operator, so fetch_express()'s own
+        # operand-reading loop already stops cleanly right before it -
+        # this picks up exactly where that left off.
+        #
+        # Requires 'sivyo' - if it's missing (a malformed/incomplete
+        # ternary), token_position is rewound to right where it was
+        # before this method ever looked at 'kama', so the caller falls
+        # back to treating 'kama' as the start of a brand new statement
+        # (an ordinary if-block) exactly as it always has, rather than
+        # this method guessing at what a half-written ternary meant.
+        if self.next_token() is None or self.next_token().value != 'kama':
+            return true_value
+
+        rollback_position = self.token_position
+        self.token_position = self.token_position + 1  # land on 'kama'
+        condition = ExpressionParser(self.fetch_express()).parse()
+
+        if self.next_token() is None or self.next_token().value != 'sivyo':
+            self.token_position = rollback_position
+            return true_value
+
+        self.token_position = self.token_position + 1  # land on 'sivyo'
+        # Recursing (rather than a single fetch_express()) lets the
+        # false-branch itself be another ternary, so
+        # 'a kama x sivyo b kama y sivyo c' chains like an else-if
+        # ladder, evaluated left to right.
+        false_value = self.parse_expression_value()
+
+        return ConditionalExpression(true_value,condition,false_value)
 
     def continue_express(self,first):
         # Same operator-chaining loop as fetch_express()'s own while-loop,
@@ -1017,6 +1055,31 @@ def _fetch_instance(name):
         Error.throwException('darasa',name)
         return None
     return value
+
+
+class ConditionalExpression(Object):
+    # `<true_value> kama <condition> sivyo <false_value>` used as a
+    # value - a real inline conditional expression (Python's ternary,
+    # `x if cond else y`), e.g.
+    # `nafsi.jina = jina kama jina sawa na "Cookie" sivyo "Guest"`.
+    # Built by try_parse_ternary() (see parse_expression_value()) - not
+    # tied to any ExpressionParser operator symbol, since it isn't a
+    # binary operator at all, just two branches and a condition.
+    #
+    # Evaluated lazily: only the branch actually taken is ever
+    # evaluated, exactly like the kama/sivyo *statement* form already
+    # behaves - so a false_value that would itself error out (e.g.
+    # reading a property that's only set on the true branch) is never
+    # touched unless the condition actually picks it.
+    def __init__(self,true_value,condition,false_value):
+        self.true_value = true_value
+        self.condition = condition
+        self.false_value = false_value
+
+    def evaluate(self):
+        if self.condition.evaluate():
+            return self.true_value.evaluate()
+        return self.false_value.evaluate()
 
 
 class PropertyExpression(Object):

--- a/SymbolTable.py
+++ b/SymbolTable.py
@@ -91,6 +91,15 @@ class SymbolTable:
         # class.
         self.next_instance_id = 1
 
+        # The source line (1-indexed) of whichever statement is
+        # currently executing - updated right before every i.execute()
+        # call in every statement-list loop (kwanza's own, and every
+        # kama/wakati/huku/function-call body), so Errors.py can quote
+        # it in a runtime error message. None until the first statement
+        # actually starts executing (e.g. a script with no kwanza block
+        # at all never sets this).
+        self.current_line = None
+
 
     def new_instance_id(self):
         id_ = self.next_instance_id


### PR DESCRIPTION
Statement objects never carried forward the line number of the token they started on, so an error deep in a long script gave no clue where to look. This adds that plumbing end-to-end.

**How it works**

StatementParser.parse()'s single dispatch loop now stamps every parsed statement with .line (1-indexed; TokenObj.line, from LexicalParser, is 0-indexed). Every statement-list execution loop (kwanza's own, and every kama/wakati/huku/function-call body) sets symbolTable.current_line from it right before that statement actually runs. Errors._report() reads that value and prefixes every message with Mstari <n>:, so any error raised while a statement is executing — including one that bubbles up from deep inside a nested expression — is automatically attributed to the right line, with no per-expression-node plumbing needed.

`Mstari 4: Kosa La Anwani: Jina hili {umri} halijulikani`

Two cases needed explicit handling rather than relying on current_line:

leta (Kosa La Leta) fails at parse time, before current_line would even reflect it, so its own line is threaded through throwException()'s new optional line argument instead.
A runaway loop (Kosa La Mzunguko) quotes the loop statement's own line rather than whatever body statement happened to be running when the 100,000-iteration cap hit, since the loop itself is what's actually wrong.

**Docs**

README.md's "Error messages" section explains the prefix and calls out both exceptions above. CHANGELOG.md has a matching entry under ## Unreleased.

**Testing**

A 12-case harness covering every error category (undefined variable/function, index/list/import errors, loop limit) across every execution context (top-level, inside kama/wakati/huku, inside a function body, inside a class method, and leta's parse-time path) — all passing. Full existing regression suite (test_v1_0_3.ham, main.py's built-in sample) re-run with no regressions. Built and verified independently on top of current main, so it merges cleanly regardless of the still-open inline-conditional PR's status.
