### PR TITLE
Quote a column in error messages; add IDE line numbers + cursor position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- **Runtime errors now also quote a column, not just a line** - the
+  `Mstari <n>:` prefix is now `Mstari <n>, Nafasi <m>:` ("Line n,
+  Position m"), where `m` is how many characters into that line the
+  failing statement starts. Threaded through the same way the line
+  number already was: `StatementParser.parse()` stamps a `.column`
+  (from the starting token's `TokenObj.start`, 0-indexed, +1 to match
+  how an editor counts columns from 1) onto every parsed statement
+  alongside `.line`; `symbolTable.current_column` is kept up to date
+  next to `current_line` by every statement-list execution loop;
+  `Errors._report()` reads both and falls back to just the line (no
+  change from before) if only a line is available. The same two
+  special cases as the line-number feature carry over unchanged:
+  `leta` (parse-time) and `mzunguko` (quotes the loop's own header
+  position, not wherever the body last ran).
+
+### Desktop IDE (`Notepad.py`)
+
+- **Added a line-number gutter** down the left edge of the code
+  editor - a `TextLineNumbers` canvas that redraws from Tk's own
+  `dlineinfo()`, so it always lines up with the text beside it
+  regardless of scrolling or resizing, and numbers each logical
+  source line exactly once even if it wraps onto multiple display
+  rows. Matches whichever light/dark editor theme is active.
+- **Added a status bar below the editor showing the text cursor's
+  current line and column** - updated as you type or click around,
+  using the same 1-indexed column convention as a `Mstari <n>, Nafasi
+  <m>:` error message, so the two are easy to cross-reference.
+
 ## v1.0.3 — language feature expansion + interpreter fixes
 
 This is a large update that brings the interpreter up to date with an

--- a/Errors.py
+++ b/Errors.py
@@ -10,23 +10,33 @@
 # symbol table to stop the script via symbolTable.exit(1).
 from SymbolTable import symbolTable
 
-def _report(message,line=None):
+def _report(message,line=None,column=None):
     # Route error text through whatever console the current run is using
     # (Tk Text widget, the web IDE's console shim, ...) so it's actually
     # visible there, same as chapa output. Falls back to print() for the
     # plain CLI (main.py), which never sets a console.
     #
-    # Prefixes the source line whenever one's available - either passed
-    # explicitly (see Errors.throwException's 'line' argument, used for
-    # 'leta', which fails at parse time rather than execute time) or,
-    # for every other error, symbolTable.current_line - kept up to date
-    # by every statement-list execution loop (StatementParser.parse()'s
-    # own, and every kama/wakati/huku/function-call body) right before
-    # each statement actually runs. Falls back to no prefix at all only
-    # if neither is set (e.g. an error somehow raised before any
-    # statement has started executing).
+    # Prefixes the source line (and, when available, the column within
+    # that line) - either passed explicitly (see Errors.throwException's
+    # 'line'/'column' arguments, used for 'leta', which fails at parse
+    # time rather than execute time, and for 'mzunguko', which quotes
+    # the loop's own header rather than wherever the body last ran) or,
+    # for every other error, symbolTable.current_line/current_column -
+    # kept up to date by every statement-list execution loop
+    # (StatementParser.parse()'s own, and every kama/wakati/huku/
+    # function-call body) right before each statement actually runs.
+    # Falls back to no prefix at all only if neither line nor column is
+    # set (e.g. an error somehow raised before any statement has started
+    # executing); falls back to just the line, with no column, if only
+    # the line is known.
     resolved_line = line if line is not None else symbolTable.current_line
-    prefix = 'Mstari {}: '.format(resolved_line) if resolved_line is not None else ''
+    resolved_column = column if column is not None else symbolTable.current_column
+    if resolved_line is not None and resolved_column is not None:
+        prefix = 'Mstari {}, Nafasi {}: '.format(resolved_line,resolved_column)
+    elif resolved_line is not None:
+        prefix = 'Mstari {}: '.format(resolved_line)
+    else:
+        prefix = ''
     full_message = '{}{}'.format(prefix,message)
 
     if symbolTable.console is not None:
@@ -59,35 +69,37 @@ class Errors:
 
         }
 
-    def throwException(self,arg,args='',line=None):
+    def throwException(self,arg,args='',line=None,column=None):
         # Looks up the exception class for `arg` (e.g. 'anwani'),
-        # constructs one with the extra details (`args`, `line`), and
-        # immediately runs it. `self.exceptions[arg](args,line)` reads
-        # as: fetch the class, then call it like a function to build an
-        # instance - `.execute()` right after that is what actually
-        # prints the message and stops the script.
-        self.exceptions[arg](args,line).execute()
+        # constructs one with the extra details (`args`, `line`,
+        # `column`), and immediately runs it. `self.exceptions[arg](args,
+        # line,column)` reads as: fetch the class, then call it like a
+        # function to build an instance - `.execute()` right after that
+        # is what actually prints the message and stops the script.
+        self.exceptions[arg](args,line,column).execute()
 
 class VariableReferenceException:
 
-    def __init__(self,arg,line=None):
+    def __init__(self,arg,line=None,column=None):
         self.name = arg
         self.line = line
+        self.column = column
 
     def execute(self):
-        _report('Kosa La Anwani: Jina hili {' +self.name +'} halijulikani',self.line)
+        _report('Kosa La Anwani: Jina hili {' +self.name +'} halijulikani',self.line,self.column)
         symbolTable.exit(1)
 
 
 class FunctionReferenceException:
     # 'kazi' = Swahili for "job/task" - used here for "function".
 
-    def __init__(self,arg,line=None):
+    def __init__(self,arg,line=None,column=None):
         self.name = arg
         self.line = line
+        self.column = column
 
     def execute(self):
-        _report('Kosa La Kazi: Kazi hii {' +self.name +'} haijaelezwa (undefined function)',self.line)
+        _report('Kosa La Kazi: Kazi hii {' +self.name +'} haijaelezwa (undefined function)',self.line,self.column)
         symbolTable.exit(1)
 
 
@@ -96,12 +108,13 @@ class LoopLimitException:
     # became false ran too many iterations and was stopped, rather than
     # freezing the page forever.
 
-    def __init__(self,arg,line=None):
+    def __init__(self,arg,line=None,column=None):
         self.name = arg
         self.line = line
+        self.column = column
 
     def execute(self):
-        _report('Kosa La Mzunguko: mzunguko {} haujaisha (loop did not end - check your condition)'.format(self.name),self.line)
+        _report('Kosa La Mzunguko: mzunguko {} haujaisha (loop did not end - check your condition)'.format(self.name),self.line,self.column)
         symbolTable.exit(1)
 
 
@@ -109,12 +122,13 @@ class IndexOutOfRangeException:
     # 'fahirisi' = Swahili for "index" - reading or writing a list
     # position that doesn't exist (negative, or past the end).
 
-    def __init__(self,arg,line=None):
+    def __init__(self,arg,line=None,column=None):
         self.name = arg
         self.line = line
+        self.column = column
 
     def execute(self):
-        _report('Kosa La Fahirisi: fahirisi hii katika {' +self.name +'} haipo (index out of range)',self.line)
+        _report('Kosa La Fahirisi: fahirisi hii katika {' +self.name +'} haipo (index out of range)',self.line,self.column)
         symbolTable.exit(1)
 
 
@@ -122,12 +136,13 @@ class NotAListException:
     # 'orodha' = Swahili for "list" - trying to index/append/loop over a
     # variable that isn't actually holding a list.
 
-    def __init__(self,arg,line=None):
+    def __init__(self,arg,line=None,column=None):
         self.name = arg
         self.line = line
+        self.column = column
 
     def execute(self):
-        _report('Kosa La Orodha: {' +self.name +'} si orodha (not a list)',self.line)
+        _report('Kosa La Orodha: {' +self.name +'} si orodha (not a list)',self.line,self.column)
         symbolTable.exit(1)
 
 
@@ -136,12 +151,13 @@ class NotAnObjectException:
     # call a method on a variable that isn't actually holding an object
     # (an instance of some darasa).
 
-    def __init__(self,arg,line=None):
+    def __init__(self,arg,line=None,column=None):
         self.name = arg
         self.line = line
+        self.column = column
 
     def execute(self):
-        _report('Kosa La Darasa: {' +self.name +'} si kitu (not an object)',self.line)
+        _report('Kosa La Darasa: {' +self.name +'} si kitu (not an object)',self.line,self.column)
         symbolTable.exit(1)
 
 
@@ -158,12 +174,13 @@ class ImportException:
     # wouldn't reflect it. StatementParser passes the leta statement's
     # own line explicitly instead - see throwException's 'line' argument.
 
-    def __init__(self,arg,line=None):
+    def __init__(self,arg,line=None,column=None):
         self.name = arg
         self.line = line
+        self.column = column
 
     def execute(self):
-        _report('Kosa La Leta: {' +self.name +'} haipatikani (import failed - check the file name, class name, or method name)',self.line)
+        _report('Kosa La Leta: {' +self.name +'} haipatikani (import failed - check the file name, class name, or method name)',self.line,self.column)
         symbolTable.exit(1)
 
 

--- a/Notepad.py
+++ b/Notepad.py
@@ -47,7 +47,104 @@ class CustomText(Text):
         if command in ("insert", "delete", "replace"):
             self.event_generate("<<TextModified>>")
 
+        # Every way the visible portion of this widget can change funnels
+        # through here too, not just edits - "yview" is exactly what
+        # scrolling (mouse wheel, Page Up/Down, dragging a scrollbar, an
+        # arrow key that pushes the cursor past the visible area, ...)
+        # actually calls under the hood, since it's the same underlying
+        # Tcl widget command we renamed and took over above. The line-
+        # number gutter needs to redraw on any of these - an edit can add
+        # or remove lines just as much as a scroll can bring new ones
+        # into view - so it listens for this broader event instead of
+        # <<TextModified>>, which stays scoped to "the text itself
+        # changed" for syntax highlighting's sake (re-tokenizing on every
+        # scroll tick would be wasted work, and visibly slower on a long
+        # script).
+        if command in ("insert", "delete", "replace", "yview"):
+            self.event_generate("<<TextViewChanged>>")
+
         return result
+
+
+class TextLineNumbers(tk.Canvas):
+    """A narrow strip drawn alongside a Text widget, showing a line
+    number next to every visible line - the familiar "gutter" down the
+    left edge of most code editors.
+
+    A Canvas (rather than e.g. a second read-only Text widget) is the
+    standard, lightweight way to do this in Tkinter: it draws only
+    plain numbers, and Tk's own dlineinfo() (see redraw() below) already
+    knows the exact pixel position of every currently-visible line, so
+    the numbers always land in the right place without this class
+    having to guess a fixed line height itself.
+    """
+
+    def __init__(self, master, **kwargs):
+        super().__init__(master, highlightthickness=0, **kwargs)
+        # Set via attach() right after construction, once the real code
+        # editor Text widget it belongs to actually exists - kept as a
+        # plain instance attribute rather than a constructor argument so
+        # this class doesn't need to know Notepad's widget-creation order.
+        self.text_widget = None
+        # Overwritten by set_colors() below to match whichever editor
+        # theme (light/dark) is active - this is just a safe fallback so
+        # redraw() has *some* color even if set_colors() is never called.
+        self._text_color = 'black'
+
+    def attach(self, text_widget):
+        """Point this gutter at the Text widget it should number."""
+        self.text_widget = text_widget
+
+    def set_colors(self, background, text_color):
+        """Match the gutter's background/number color to the editor's
+        current theme (see Notepad.__applyEditorTheme)."""
+        self._text_color = text_color
+        self.configure(bg=background)
+
+    def redraw(self, *_event_args):
+        """Erase and redraw every line number currently visible.
+
+        *_event_args soaks up whatever Tkinter passes in when this is
+        used directly as an event callback (an Event object) - redraw()
+        never needs to look at it, it just always recomputes from
+        scratch based on the text widget's current scroll position.
+        """
+        self.delete("all")
+
+        if self.text_widget is None:
+            return
+
+        # "@0,0" asks the text widget "what character index is showing
+        # at pixel position (0,0)?" - i.e. wherever the very first
+        # visible line is right now, however far the user has scrolled.
+        index = self.text_widget.index("@0,0")
+
+        while True:
+            # dlineinfo() returns None once `index` scrolls past the
+            # last actually-visible display line (e.g. below the bottom
+            # of the window) - the natural place for this loop to stop.
+            dline_info = self.text_widget.dlineinfo(index)
+            if dline_info is None:
+                break
+
+            # dlineinfo()'s 2nd element is the line's top-left y pixel
+            # position within the text widget - exactly where this
+            # number needs to be drawn to line up with it.
+            y_position = dline_info[1]
+            line_number = str(index).split('.')[0]
+            self.create_text(
+                2, y_position,
+                anchor='nw',
+                text=line_number,
+                font=self.text_widget['font'],
+                fill=self._text_color,
+            )
+
+            # Advance by one logical source line - not one *display*
+            # line - so a long line that wraps onto several display rows
+            # still only gets numbered once, at the top, the same way
+            # every other code editor's gutter behaves.
+            index = self.text_widget.index('{}+1line'.format(index))
 
 
 class Notepad:
@@ -75,10 +172,6 @@ class Notepad:
         self.__thisCodeFrame = ttk.Frame(self.__root)
         self.__thisCodeFrame.pack(fill='both', expand=1)
 
-        # Create the text area for code editing
-        self.__thisTextArea = CustomText(self.__thisCodeFrame, font=("Courier", 12, "normal"))
-        self.__thisTextArea.pack(side=TOP, fill='both', expand=1)
-
         # A visible in-window toolbar with a Run button - on macOS the Menu
         # bar below is drawn in the system menu bar at the top of the
         # screen (not inside the window itself), and a Tk app launched
@@ -95,6 +188,35 @@ class Notepad:
         self.__thisClearConsoleButton.pack(side=LEFT, padx=4, pady=4)
         self.__thisThemeButton = ttk.Button(self.__thisToolbar, text="Dark Mode", command=self.__toggleEditorTheme)
         self.__thisThemeButton.pack(side=LEFT, padx=4, pady=4)
+
+        # The code editor itself, plus its line-number gutter, side by
+        # side in their own frame - keeping them together like this
+        # means the status bar and console below can be packed against
+        # the codeFrame without needing to know anything about the
+        # gutter living next to the text area.
+        self.__thisEditorFrame = ttk.Frame(self.__thisCodeFrame)
+        self.__thisEditorFrame.pack(side=TOP, fill='both', expand=1)
+
+        # Create the text area for code editing
+        self.__thisTextArea = CustomText(self.__thisEditorFrame, font=("Courier", 12, "normal"))
+
+        # The gutter needs to exist before it can be told which text
+        # widget to number (attach(), right after), and packed to the
+        # left of it so the numbers appear on the left edge of the
+        # editor, matching the convention every other code editor uses.
+        self.__thisLineNumbers = TextLineNumbers(self.__thisEditorFrame, width=40)
+        self.__thisLineNumbers.attach(self.__thisTextArea)
+        self.__thisLineNumbers.pack(side=LEFT, fill='y')
+
+        self.__thisTextArea.pack(side=LEFT, fill='both', expand=1)
+
+        # A thin status bar just below the editor, showing where the
+        # text cursor currently is - updated by __updateCursorPosition,
+        # bound further below.
+        self.__thisStatusBar = ttk.Frame(self.__thisCodeFrame)
+        self.__thisStatusBar.pack(side=TOP, fill='x')
+        self.__thisPositionLabel = ttk.Label(self.__thisStatusBar, text="Line 1, Col 1", anchor='w')
+        self.__thisPositionLabel.pack(side=LEFT, padx=6, pady=2)
 
         # Create the console for displaying output
         self.__thisConsole = CustomText(self.__thisCodeFrame, font=("Courier", 12, "normal"), height=18, bg="black", fg="white")
@@ -139,14 +261,36 @@ class Notepad:
         self.__thisHelpMenu.add_command(label="Open Hamri Documentation", command=self.__openDocumentation)
         self.__thisMenuBar.add_cascade(label="Help", menu=self.__thisHelpMenu)
 
-        # Bind events to the text area
+        # Bind events to the text area. add='+' on every binding past the
+        # first one for the same event is required here - Tkinter's
+        # .bind() *replaces* any existing callback for a given sequence
+        # on a widget by default, so without it each of these would
+        # silently discard whatever was bound right before it instead of
+        # running alongside it.
         self.__thisTextArea.bind("<<TextModified>>", self.__generateTags)
+        # The gutter redraws on <<TextViewChanged>> (see CustomText._proxy)
+        # rather than <<TextModified>> - it needs to catch scrolling too,
+        # not just edits, which <<TextModified>> deliberately doesn't cover.
+        self.__thisTextArea.bind("<<TextViewChanged>>", self.__thisLineNumbers.redraw, add='+')
+        self.__thisTextArea.bind("<KeyRelease>", self.__updateCursorPosition, add='+')
+        self.__thisTextArea.bind("<ButtonRelease-1>", self.__updateCursorPosition, add='+')
+        # Catches the editor being resized (e.g. the whole window being
+        # resized) - dlineinfo()'s pixel positions shift when that
+        # happens, even without any scrolling or editing taking place.
+        self.__thisLineNumbers.bind("<Configure>", self.__thisLineNumbers.redraw)
 
         # Keyboard shortcut for running the script (Cmd+R on macOS,
         # Ctrl+R elsewhere) as a second fallback alongside the Run button,
         # independent of the File menu / menu bar entirely.
         self.__root.bind_all("<Command-r>", lambda event: self.__execute())
         self.__root.bind_all("<Control-r>", lambda event: self.__execute())
+
+        # Give the gutter and status bar their correct starting
+        # appearance/content immediately, rather than waiting for the
+        # first keystroke or click to trigger it via the bindings above.
+        self.__thisLineNumbers.set_colors('#f0f0f0', '#666666')
+        self.__thisLineNumbers.redraw()
+        self.__updateCursorPosition()
 
     # Maps each of the lexer's actual token type strings (see the `Tokens`
     # enum in LexicalParser.py - 'keyword', 'variable', 'operator',
@@ -318,6 +462,19 @@ class Notepad:
         # a number), so treat that the same as an empty response.
         return result if result is not None else ""
 
+    def __updateCursorPosition(self, event=None):
+        """Refresh the status bar with the text cursor's current line
+        and column, e.g. after the user types or clicks somewhere new.
+
+        Text widget indices come back as a "line.column" string, with
+        the line already 1-indexed the way an editor shows it - but the
+        column half is 0-indexed, so it needs its own +1 here to match
+        (and to match the 1-indexed "Nafasi" position Errors.py quotes
+        in a runtime error message, for the same underlying reason).
+        """
+        line, column = self.__thisTextArea.index(INSERT).split(".")
+        self.__thisPositionLabel.config(text="Line {}, Col {}".format(line, int(column) + 1))
+
     def __clearEditor(self):
         """Clear all text out of the code editor"""
         self.__thisTextArea.delete("1.0", "end")
@@ -329,16 +486,21 @@ class Notepad:
     def __applyEditorTheme(self, dark):
         """Switch the code editor's background between light and dark.
 
-        Scoped to the editor only - the console already has its own
-        fixed black/white look (see __init__) and isn't affected here.
+        Scoped to the editor (and its line-number gutter) only - the
+        console already has its own fixed black/white look (see
+        __init__) and isn't affected here.
         """
         self.__editorDarkMode = dark
         if dark:
             bg, fg, insertbg, selectbg = '#1e1e1e', '#f1f1f1', '#f1f1f1', '#3d5a73'
+            gutter_bg, gutter_fg = '#1e1e1e', '#6e7681'
         else:
             bg, fg, insertbg, selectbg = '#ffffff', '#000000', '#000000', '#c3d9ff'
+            gutter_bg, gutter_fg = '#f0f0f0', '#666666'
         self.__thisTextArea.config(bg=bg, fg=fg, insertbackground=insertbg, selectbackground=selectbg)
         self.__thisThemeButton.config(text="Light Mode" if dark else "Dark Mode")
+        self.__thisLineNumbers.set_colors(gutter_bg, gutter_fg)
+        self.__thisLineNumbers.redraw()
 
         # Re-apply syntax highlighting immediately with the new theme's
         # colors (see _TOKEN_COLORS) rather than waiting for the next

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ this repo, no external dependencies beyond the Python standard library
    Write or open a script in the text area, then use the "Run ▶" button
    (or `Cmd+R` / `Ctrl+R`, or File > Execute) to run it — output appears
    in the console pane below. "Clear Editor" and "Clear Console" (also
-   in the File menu) reset either pane.
+   in the File menu) reset either pane. A line-number gutter runs down
+   the left edge of the editor, and a status bar just below it shows
+   the text cursor's current line and column — handy for matching up
+   an error message's `Mstari <n>, Nafasi <m>:` prefix with the exact
+   spot in your script.
 
    Tkinter isn't part of the Python standard install on every platform.
    If `python3 Notepad.py` fails with `ModuleNotFoundError: No module
@@ -603,16 +607,18 @@ kwisha
 
 Hamri reports runtime errors in Swahili and stops the script (exit code
 1) rather than continuing silently. Every message is prefixed with
-`Mstari <n>:` ("Line n") — the source line the failing statement
-started on — so you don't have to guess which part of a long script
-actually went wrong:
+`Mstari <n>, Nafasi <m>:` ("Line n, Position m") — the source line the
+failing statement started on, and how many characters into that line
+it starts — so you don't have to guess which part of a long script (or
+which of several statements crammed onto one line) actually went
+wrong:
 
 ```
-Mstari 4: Kosa La Anwani: Jina hili {umri} halijulikani
+Mstari 4, Nafasi 5: Kosa La Anwani: Jina hili {umri} halijulikani
 ```
 
-The quoted line is always the *statement* that was running when the
-error happened — the `chapa`/`kama`/`wakati`/function-call line itself,
+The quoted position is always the *statement* that was running when
+the error happened — the `chapa`/`kama`/`wakati`/function-call itself,
 not some internal detail of how the expression inside it was built.
 That's true even when the failure comes from deep inside a nested
 expression (e.g. an undefined property read as part of a larger
@@ -620,10 +626,10 @@ expression (e.g. an undefined property read as part of a larger
 that couldn't find its file (reported at parse time, before the script
 even starts running, since `leta` has no runtime step of its own). A
 runaway `wakati`/`huku` loop (`Kosa La Mzunguko`) is the one exception
-worth calling out — it quotes the loop's own header line, not whatever
-body statement happened to be running on the iteration that tripped
-the 100,000-iteration cap, since the loop itself (not that particular
-statement) is what's actually wrong.
+worth calling out — it quotes the loop's own header position, not
+whatever body statement happened to be running on the iteration that
+tripped the 100,000-iteration cap, since the loop itself (not that
+particular statement) is what's actually wrong.
 
 | Message | Cause |
 |---|---|

--- a/StatementParser.py
+++ b/StatementParser.py
@@ -254,22 +254,23 @@ class StatementParser:
 
             # leta has no runtime behaviour of its own (see _parse_module),
             # so a failed import is reported right here, at parse time -
-            # symbolTable.current_line (updated only as statements
-            # *execute*) wouldn't reflect this line, so it's passed
-            # through explicitly instead.
+            # symbolTable.current_line/current_column (updated only as
+            # statements *execute*) wouldn't reflect this location, so
+            # it's passed through explicitly instead.
             leta_line = parse_token.line + 1
+            leta_column = parse_token.start + 1
 
             if after_kutoka is not None and after_kutoka.token_type == 'string':
                 self.token_position = self.token_position + 1  # land on the filename string
                 filename = self.tokens[self.token_position].value
-                self.import_classes(names,filename,leta_line)
+                self.import_classes(names,filename,leta_line,leta_column)
             else:
                 class_name = after_kutoka.value if after_kutoka is not None else None
                 self.token_position = self.token_position + 1  # land on <class-name>
                 self.token_position = self.token_position + 1  # land on 'kutoka'
                 self.token_position = self.token_position + 1  # land on the filename string
                 filename = self.tokens[self.token_position].value
-                self.import_methods(names,class_name,filename,leta_line)
+                self.import_methods(names,class_name,filename,leta_line,leta_column)
 
         elif parse_token.value == 'kwanza':
             Log('case for main block')
@@ -408,26 +409,26 @@ class StatementParser:
 
         return True
 
-    def import_classes(self,names,filename,line=None):
+    def import_classes(self,names,filename,line=None,column=None):
         # 'leta A, B kutoka "faili"' - pulls in one or more whole classes.
         if not self._parse_module(filename):
-            Error.throwException('leta',filename,line)
+            Error.throwException('leta',filename,line,column)
             return
         for name in names:
             if name not in symbolTable.table['classes']:
-                Error.throwException('leta','{} ({})'.format(name,filename),line)
+                Error.throwException('leta','{} ({})'.format(name,filename),line,column)
 
-    def import_methods(self,names,class_name,filename,line=None):
+    def import_methods(self,names,class_name,filename,line=None,column=None):
         # 'leta a, b kutoka ClassName kutoka "faili"' - pulls in one or
         # more specific methods of a class, callable standalone (see
         # SymbolTable.alias_function).
         if not self._parse_module(filename):
-            Error.throwException('leta',filename,line)
+            Error.throwException('leta',filename,line,column)
             return
         for name in names:
             qualified_name = 'darasa-{}-{}'.format(class_name,name)
             if not symbolTable.alias_function(name,qualified_name):
-                Error.throwException('leta','{}.{} ({})'.format(class_name,name,filename),line)
+                Error.throwException('leta','{}.{} ({})'.format(class_name,name,filename),line,column)
 
     def try_parse_special_value(self):
         # Tries each of the "not a plain fetch_express() expression"
@@ -760,10 +761,18 @@ class StatementParser:
             # (error messages) matches what they'd count in an editor.
             start_line = self.tokens[self.token_position].line + 1
 
+            # Same idea as start_line above, but for the column: how many
+            # characters into that line the statement's first token
+            # starts (TokenObj.start, from LexicalParser - also 0-indexed,
+            # so +1 here too, matching how a text editor numbers columns
+            # starting from 1 rather than 0).
+            start_column = self.tokens[self.token_position].start + 1
+
             statement = self.parseStatement(self.tokens[self.token_position])
 
             if statement is not None:
                 statement.line = start_line
+                statement.column = start_column
 
             #print('Function definition flag:',symbolTable.def_flag)
 
@@ -856,6 +865,7 @@ class StatementParser:
                 Log('kwanza','Executing from scope')
                 Log(i,'Executing statement')
                 symbolTable.current_line = i.line
+                symbolTable.current_column = i.column
                 i.execute()
 
             else:
@@ -984,6 +994,7 @@ class FunctionCallStatement(Statement):
             Log(i,'Executing statement')
 
             symbolTable.current_line = i.line
+            symbolTable.current_column = i.column
             i.execute()
 
         # This is the function-call boundary: absorb the return flag here
@@ -1362,6 +1373,7 @@ class IfStatement(Statement):
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
                 symbolTable.current_line = i.line
+                symbolTable.current_column = i.column
                 i.execute()
         elif self.else_name is not None:
             Log('condition false, executing sivyo-block {}'.format(self.else_name),'If Execution')
@@ -1369,6 +1381,7 @@ class IfStatement(Statement):
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
                 symbolTable.current_line = i.line
+                symbolTable.current_column = i.column
                 i.execute()
         else:
             Log('condition false, no sivyo branch, skipping','If Execution')
@@ -1392,16 +1405,18 @@ class WhileStatement(Statement):
                 break
             iterations = iterations + 1
             if iterations > self.MAX_ITERATIONS:
-                # self.line (not symbolTable.current_line, which by now
-                # would just hold whatever body statement last ran) -
-                # the loop's own header line is more useful here than
-                # wherever execution happened to be when it gave up.
-                Error.throwException('mzunguko',self.name,self.line)
+                # self.line/self.column (not symbolTable.current_line/
+                # current_column, which by now would just hold wherever
+                # the body statement last ran) - the loop's own header
+                # position is more useful here than wherever execution
+                # happened to be when it gave up.
+                Error.throwException('mzunguko',self.name,self.line,self.column)
                 break
             for i in symbolTable.table['functions'][self.name]:
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
                 symbolTable.current_line = i.line
+                symbolTable.current_column = i.column
                 i.execute()
             if symbolTable.is_returning():
                 break
@@ -1444,11 +1459,12 @@ class ForStatement(Statement):
                 break
             iterations = iterations + 1
             if iterations > self.MAX_ITERATIONS:
-                # self.line (not symbolTable.current_line, which by now
-                # would just hold whatever body statement last ran) -
-                # the loop's own header line is more useful here than
-                # wherever execution happened to be when it gave up.
-                Error.throwException('mzunguko',self.name,self.line)
+                # self.line/self.column (not symbolTable.current_line/
+                # current_column, which by now would just hold wherever
+                # the body statement last ran) - the loop's own header
+                # position is more useful here than wherever execution
+                # happened to be when it gave up.
+                Error.throwException('mzunguko',self.name,self.line,self.column)
                 break
 
             # Same storage path as a normal assignment (Var mode 1) -
@@ -1464,6 +1480,7 @@ class ForStatement(Statement):
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
                 symbolTable.current_line = i.line
+                symbolTable.current_column = i.column
                 i.execute()
 
             if symbolTable.is_returning():
@@ -1503,6 +1520,7 @@ class ForEachStatement(Statement):
                 if symbolTable.exit() != 0 or symbolTable.is_returning():
                     break
                 symbolTable.current_line = i.line
+                symbolTable.current_column = i.column
                 i.execute()
 
             if symbolTable.is_returning():

--- a/SymbolTable.py
+++ b/SymbolTable.py
@@ -100,6 +100,13 @@ class SymbolTable:
         # at all never sets this).
         self.current_line = None
 
+        # Same idea as current_line, but the column (1-indexed
+        # character position within that line) the statement started
+        # on - set alongside current_line everywhere it's set, so
+        # Errors.py can quote a precise "line, column" location instead
+        # of just a line.
+        self.current_column = None
+
 
     def new_instance_id(self):
         id_ = self.next_instance_id


### PR DESCRIPTION
## What this PR does

**Error messages now quote a column, not just a line.** The
`Mstari <n>:` prefix becomes `Mstari <n>, Nafasi <m>:` ("Line n,
Position m"), where `m` is how many characters into that line the
failing statement starts - handy for a long or multi-statement line
where knowing the line alone doesn't narrow things down much.

Implementation mirrors the existing line-number-tracking feature
exactly, just for column instead of line:
- `StatementParser.parse()`'s dispatch loop now also stamps a
  `.column` onto every parsed statement (from the starting token's
  `TokenObj.start`, 0-indexed, +1 to match how an editor counts
  columns from 1).
- `symbolTable.current_column` mirrors `current_line`, kept up to
  date by every statement-list execution loop right before each
  statement runs.
- `Errors._report()` reads both and formats `Mstari <n>, Nafasi <m>:`
  when both are available, falling back to just `Mstari <n>:` (no
  change from before) if only the line is known.
- The same two special cases as the line-number feature carry over:
  `leta` (fails at parse time, so its own line/column are passed
  through explicitly) and `mzunguko` (quotes the loop's own header
  position rather than wherever the body last ran when the
  100,000-iteration cap hits).

**Desktop IDE (`Notepad.py`) gets a line-number gutter and a cursor
position status bar.**
- `TextLineNumbers`, a new small `tkinter.Canvas` subclass, draws a
  number next to every visible line using Tk's own `dlineinfo()` -
  this keeps it pixel-accurate against the text beside it regardless
  of scrolling or resizing, and (since it advances by logical line,
  not display line) numbers a wrapped long line only once, at its
  top - the same convention every other code editor uses.
- `CustomText._proxy` (which already intercepts every Tcl command on
  the text widget to detect edits for syntax highlighting) now also
  fires a `<<TextViewChanged>>` event on `yview` calls - covering
  scrolling (mouse wheel, Page Up/Down, ...) - which the gutter
  listens for to know when to redraw, kept deliberately separate from
  `<<TextModified>>` so syntax highlighting doesn't re-tokenize on
  every scroll tick.
- A new status bar directly below the editor shows the text cursor's
  current line/column (`self.__thisTextArea.index(INSERT)`), updated
  on `<KeyRelease>`/`<ButtonRelease-1>`, using the same 1-indexed
  column convention as the `Mstari`/`Nafasi` error prefix.
- Both the gutter and the status bar are wired into
  `__applyEditorTheme` so they switch color correctly with the
  existing light/dark toggle.

## Testing

- `python3 -m py_compile *.py` - clean compile.
- `python3 main.py` and all four `tests/*.ham` scripts - output
  unchanged aside from the new `Nafasi` prefix on error messages.
- Manually traced through `TextLineNumbers`/`CustomText._proxy`/the
  new bindings in `Notepad.py` - couldn't execute the Tkinter GUI
  itself in this environment (no display, `tkinter` unavailable), so
  please give the gutter/status-bar/theme-toggle interplay a look in
  a real run before merging.

## Notes for the reviewer

This does not touch `hamri-website` - that's covered in a separate
PR against that repo (the same `Errors.py`/`StatementParser.py`/
`SymbolTable.py` column-tracking changes mirrored into
`modules/`, plus the Playground's own line-number gutter and cursor
position display, implemented directly in JS/CSS since it's a plain
HTML `&lt;textarea&gt;`-based editor rather than Tkinter).
